### PR TITLE
Match RBX::myLess::operator() and CollisionStage::getMetric

### DIFF
--- a/Client/App/v8world/Block.cpp
+++ b/Client/App/v8world/Block.cpp
@@ -11,11 +11,15 @@ namespace RBX
 	{
 		bool operator()(const G3D::Vector3& a, const G3D::Vector3& b) const
 		{
-			if (a.x >= b.x || a.x > b.x)
+			if (a.x < b.x)
 				return true;
-			if (a.y >= b.y || a.y > b.y)
+			if (a.x > b.x)
+				return false;
+			if (a.y < b.y)
 				return true;
-			if (a.z >= b.z)
+			if (a.y > b.y)
+				return false;
+			if (a.z < b.z)
 				return true;
 			return false;
 		}

--- a/Client/App/v8world/Clump.cpp
+++ b/Client/App/v8world/Clump.cpp
@@ -168,10 +168,10 @@ namespace RBX
 		}
 	}
 
-	// 100% match if isSpanningJoint has __forceinline
 	void Clump::renumberSpanTree(Primitive* onTree)
 	{
-		for (RigidJoint* r = onTree->getFirstRigid(); r != NULL; r = onTree->getNextRigid(r))
+		RigidJoint* r = onTree->getFirstRigid();
+		while (r != NULL)
 		{
 			Primitive* p = SpanLink::isSpanningJoint(r);
 
@@ -181,6 +181,7 @@ namespace RBX
 				other->setClumpDepth(onTree->getClumpDepth() + 1);
 				renumberSpanTree(other);
 			}
+			r = onTree->getNextRigid(r);
 		}
 	}
 

--- a/Client/App/v8world/CollisionStage.cpp
+++ b/Client/App/v8world/CollisionStage.cpp
@@ -224,12 +224,14 @@ namespace RBX
 
 	int CollisionStage::getMetric(MetricType metricType)
 	{
-		if (metricType == NUM_CONTACTSTAGE_CONTACTS)
+		switch (metricType) {
+		case NUM_CONTACTSTAGE_CONTACTS:
 			return numContactsInStage;
-		else if (metricType == NUM_STEPPING_CONTACTS)
+		case NUM_STEPPING_CONTACTS:
 			return stepping.size();
-		
-		return IWorldStage::getMetric(metricType);
+		default:
+			return IWorldStage::getMetric(metricType);
+		}
 	}
 
 	void CollisionStage::onAssemblyAdded(Assembly* assembly)

--- a/Client/App/v8world/CollisionStage.cpp
+++ b/Client/App/v8world/CollisionStage.cpp
@@ -224,7 +224,8 @@ namespace RBX
 
 	int CollisionStage::getMetric(MetricType metricType)
 	{
-		switch (metricType) {
+		switch (metricType)
+		{
 		case NUM_CONTACTSTAGE_CONTACTS:
 			return numContactsInStage;
 		case NUM_STEPPING_CONTACTS:


### PR DESCRIPTION
getMetric used a small switch statement, which generated subtraction instructions instead of a switch table. common for small switch cases I think