### PR TITLE
fix instruction ordering when calling ComputeProp<T,U>::setDirty

### DIFF
--- a/Client/App/include/util/ComputeProp.h
+++ b/Client/App/include/util/ComputeProp.h
@@ -45,8 +45,9 @@ namespace RBX
 
 		bool setDirty() const
 		{
+			bool old = dirty;
 			dirty = true;
-			return true; // TODO: this is a placeholder return. figure out the true value.
+			return old; // TODO: this is a placeholder return. figure out the true value.
 		}
 	};
 }


### PR DESCRIPTION
return value is a guess based on what the function does