### PR TITLE
Match SimJobStage::combineMechanisms and SleepStage::checkSleepingAssemblies

### DIFF
--- a/Client/App/v8world/SimJobStage.cpp
+++ b/Client/App/v8world/SimJobStage.cpp
@@ -114,16 +114,11 @@ namespace RBX
 		Mechanism* m1 = a1->getMechanism();
 		if (m0 != m1)
 		{
-			if (m0->getAssemblies().size() > m1->getAssemblies().size())
-			{
-				m0->absorb(m1);
-				destroyMechanism(m1);
-			}
-			else
-			{
-				m1->absorb(m0);
-				destroyMechanism(m0);
-			}
+			Mechanism* m = (m0->getAssemblies().size() > m1->getAssemblies().size()) ? m0 : m1;
+			Mechanism* other = (m == m1) ? m0 : m1;
+
+			m->absorb(other);
+			destroyMechanism(other);
 		}
 	}
 

--- a/Client/App/v8world/SleepStage.cpp
+++ b/Client/App/v8world/SleepStage.cpp
@@ -379,14 +379,14 @@ namespace RBX
 
 			Sim::AssemblyState state = shouldWakeOrSleepDeeply(assembly);
 
-			if (state != Sim::AWAKE)
+			switch (state)
 			{
-				if (state == Sim::SLEEPING_DEEPLY)
-					tempToDeep.append(assembly);
-			}
-			else
-			{
+			case Sim::AWAKE:
 				tempToWake.append(assembly);
+				break;
+			case Sim::SLEEPING_DEEPLY:
+				tempToDeep.append(assembly);
+				break;
 			}
 		}
 


### PR DESCRIPTION
I had noticed before that both of the calls to Mechanism::absorb and SimJobStage::destroyMechanism were on the same lines, so that meant that there was code that was swapping the mechanisms. I finally managed to get it to match by having the other mechanism be figured out using the biggest mechanism. SleepStage::checkSleepingAssemblies had some comparisons that used subtraction instructions, so that meant that it was a switch.