### PR TITLE
Add Link destructor and omit Edge vtable

### DIFF
--- a/Client/App/include/v8kernel/Link.h
+++ b/Client/App/include/v8kernel/Link.h
@@ -19,7 +19,7 @@ namespace RBX
 			//void setBody(RBX::Body* _body){ body = _body;}
 		public:
 			Link();
-			//~Link();
+			~Link();
 			const G3D::CoordinateFrame& getChildInParent() const;
 			Body* getBody() const;
 			void reset(const G3D::CoordinateFrame&, const G3D::CoordinateFrame&);

--- a/Client/App/include/v8world/Edge.h
+++ b/Client/App/include/v8world/Edge.h
@@ -17,7 +17,7 @@ namespace RBX
 		};
 	}
 
-	class Edge : public IPipelined
+	class __declspec(novtable) Edge : public IPipelined
 	{
 	public:
 		enum EdgeType

--- a/Client/App/v8kernel/Link.cpp
+++ b/Client/App/v8kernel/Link.cpp
@@ -5,6 +5,10 @@ using namespace RBX;
 
 Link::Link():body(NULL) {stateIndex = Body::getNextStateIndex();}
 
+Link::~Link()
+{
+}
+
 void Link::dirty()
 {
 	if (body)

--- a/Client/App/v8world/MotorJoint.cpp
+++ b/Client/App/v8world/MotorJoint.cpp
@@ -19,8 +19,7 @@ namespace RBX
 
 	MotorJoint::~MotorJoint()
 	{
-		if (link)
-			delete link;
+		delete link;
 	}
 
 	G3D::CoordinateFrame MotorJoint::getMeInOther(Primitive* me)


### PR DESCRIPTION
adding the link destructor and putting the function in Link.cpp makes the MotorJoint destructor match, and omitting the Edge vtable makes the Joint destructor match. not sure what other matches there may be.