### PR TITLE
Notifier-related matches + other improvements

### DIFF
--- a/Client/App/humanoid/Humanoid.cpp
+++ b/Client/App/humanoid/Humanoid.cpp
@@ -516,7 +516,6 @@ namespace RBX
 		}
 	}
 
-
 	void Humanoid::setTorso(PartInstance* value)
 	{
 		if (torso.get() != value)
@@ -524,5 +523,17 @@ namespace RBX
 			torso = shared_from(value);
 			raisePropertyChanged(propTorso);
 		}
+	}
+
+	void Humanoid::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
+	{
+		Notifier<RunService, Stepped>::disconnect(ServiceProvider::create<RunService>(oldProvider), this);
+		
+		Instance::onServiceProvider(oldProvider, newProvider);
+
+		Notifier<RunService, Stepped>::connect(ServiceProvider::create<RunService>(newProvider), this);
+
+		if (newProvider && !oldProvider)
+			onLocalHumanoidEnteringWorkspace();
 	}
 }

--- a/Client/App/include/humanoid/Humanoid.h
+++ b/Client/App/include/humanoid/Humanoid.h
@@ -198,7 +198,7 @@ namespace RBX
 		void setState(State*);
 		void checkForJointDeath();
 		bool hasWalkToPoint(G3D::Vector3& worldPosition) const;
-		virtual void onServiceProvider(const ServiceProvider*, const ServiceProvider*);
+		virtual void onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider);
 		virtual void onAncestorChanged(const AncestorChanged& event);
 		virtual bool askSetParent(const Instance*) const;
 		virtual bool shouldRender2d() const;

--- a/Client/App/include/util/NormalId.h
+++ b/Client/App/include/util/NormalId.h
@@ -22,6 +22,9 @@ namespace RBX
 	NormalId Matrix3ToNormalId(const G3D::Matrix3& m);
 	NormalId intToNormalId(int num);
 
+	NormalId normalIdToU(NormalId id);
+	NormalId normalIdToV(NormalId id);
+
 	const G3D::Vector3& normalIdToVector3(NormalId normalId);
 	const G3D::Matrix3& normalIdToMatrix3(NormalId normalId);
 
@@ -34,6 +37,4 @@ namespace RBX
 
 	G3D::Vector3 objectToUvw(const G3D::Vector3& objectPt, NormalId faceId);
 	G3D::Vector3 mapToUvw_Legacy(const G3D::Vector3& ptInObject, NormalId faceId);
-
-
 }

--- a/Client/App/include/util/Utilities.h
+++ b/Client/App/include/util/Utilities.h
@@ -20,8 +20,9 @@ namespace RBX
 		{
 		}
 	public:
-		// TODO: is this definition right?
-		operator boost::shared_ptr<const T>() const
+		// this allows functions to easily check if object is NULL
+		// VERY hacky...
+		operator typename boost::shared_ptr<T>::unspecified_bool_type() const
 		{
 			return object;
 		}

--- a/Client/App/include/v8datamodel/LocalBackpack.h
+++ b/Client/App/include/v8datamodel/LocalBackpack.h
@@ -58,16 +58,16 @@ namespace RBX
 		{
 			return true;
 		}
-		virtual void onServiceProvider(const ServiceProvider*, const ServiceProvider*);
+		virtual void onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider);
 		virtual void onEvent(const Network::Player* source, Network::CharacterRemoving event);
 		virtual void onEvent(const Network::Player* source, Network::CharacterAdded event);
 		virtual void onEvent(const Instance* source, DescendentRemoving event);
 		virtual void onEvent(const Instance* source, DescendentAdded event);
 		virtual void onEvent(const Instance* source, ChildRemoved event);
 		virtual void onEvent(const Instance* source, ChildAdded event);
-		void onLocalCharacterAdded(Instance*);
-		void onLocalPlayerAdded(Network::Player*);
-		void onLocalBackpackAdded(Backpack*);
+		void onLocalCharacterAdded(Instance* added);
+		void onLocalPlayerAdded(Network::Player* added);
+		void onLocalBackpackAdded(Backpack* added);
 		void clearAll();
 		void clearLocalCharacter();
 		void clearLocalPlayer();

--- a/Client/App/include/v8datamodel/Workspace.h
+++ b/Client/App/include/v8datamodel/Workspace.h
@@ -63,7 +63,7 @@ namespace RBX
 		virtual void onChildChanged(Instance* instance, const PropertyChanged& event);
 		virtual void onDescendentAdded(Instance* instance);
 		virtual void onDescendentRemoving(const boost::shared_ptr<Instance>& instance);
-		virtual void onServiceProvider(const ServiceProvider*, const ServiceProvider*);
+		virtual void onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider);
 	public:
 		void setCursor(Adorn*);
 		virtual void render2d(Adorn* adorn);

--- a/Client/App/include/v8tree/Instance.h
+++ b/Client/App/include/v8tree/Instance.h
@@ -248,7 +248,7 @@ namespace RBX
 		};
 		size_t numChildren() const
 		{
-			if (&(*children))
+			if (children)
 				return children->size();
 			else
 				return 0;
@@ -369,7 +369,7 @@ namespace RBX
 		template<typename Function>
 		void for_eachChild(Function func) const
 		{
-			if (&(*children))
+			if (children)
 			{
 				boost::shared_ptr<const std::vector<boost::shared_ptr<Instance>>> c = children.read();
 				for (std::vector<boost::shared_ptr<Instance>>::const_iterator iter = c->begin(); iter != c->end(); iter++)

--- a/Client/App/script/Script.cpp
+++ b/Client/App/script/Script.cpp
@@ -101,15 +101,12 @@ void Script::onAncestorChanged(const AncestorChanged& event)
 
 void Script::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
 {
-    if (oldProvider)
-    {
-        ScriptContext* sc = oldProvider->find<ScriptContext>();
+	if (ScriptContext* sc = ServiceProvider::find<ScriptContext>(oldProvider))
+	{
+		sc->removeScript(this);
+	}
 
-        if (sc)
-            sc->removeScript(this);
-    }
-
-    Instance::onServiceProvider(oldProvider, newProvider);
+	Instance::onServiceProvider(oldProvider, newProvider);
 }
 
 boost::shared_ptr<const std::string> Script::requestCode()

--- a/Client/App/script/ScriptContext.cpp
+++ b/Client/App/script/ScriptContext.cpp
@@ -25,6 +25,7 @@ using namespace RBX;
 using namespace boost::posix_time;
 
 // unidentified inlines
+
 static inline void _openLibInline(lua_State* L, lua_CFunction f, const char* name)
 {
     lua_pushcfunction(L, f);
@@ -32,25 +33,6 @@ static inline void _openLibInline(lua_State* L, lua_CFunction f, const char* nam
     lua_call(L, 1, 0);
 }
 
-template<typename Class, typename Event>
-static inline void _addListenerInline(RunService* runService, Listener<Class, Event>* listener)
-{
-    if (runService)
-        runService->Notifier<Class, Event>::addListener(listener);
-}
-
-template<typename Class, typename Event>
-static inline void _removeListenerInline(RunService* runService, Listener<Class, Event>* listener)
-{
-    if (runService)
-        runService->Notifier<Class, Event>::removeListener(listener);
-        }
-
-static inline void _removeListenersInline(boost::shared_ptr<RunService>& runService, ScriptContext* scriptContext)
-{
-    _removeListenerInline<RunService, RunTransition>(runService.get(), scriptContext);
-    _removeListenerInline<RunService, Heartbeat>(runService.get(), scriptContext);
-}
 // end unidentified inlines
 
 Reflection::BoundProp<bool, true> ScriptContext::propScriptsDisabled("ScriptsDisabled", "State", &ScriptContext::scriptsDisabled, &ScriptContext::onChangedScriptEnabled, Reflection::PropertyDescriptor::LEGACY); 
@@ -559,7 +541,8 @@ void ScriptContext::onEvent(const RunService* source, RunTransition event)
 
 void ScriptContext::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
 {
-    _removeListenersInline(runService, this);
+	Notifier<RunService, RunTransition>::disconnect(runService, this);
+    Notifier<RunService, Heartbeat>::disconnect(runService, this);
 
     if (oldProvider && !newProvider)
         closeState();
@@ -593,8 +576,8 @@ void ScriptContext::onServiceProvider(const ServiceProvider* oldProvider, const 
     }
 
     runService = shared_from(newRunService);
-    _addListenerInline<RunService, RunTransition>(runService.get(), this);
-    _addListenerInline<RunService, Heartbeat>(runService.get(), this);
+    Notifier<RunService, RunTransition>::connect(runService, this);
+    Notifier<RunService, Heartbeat>::connect(runService, this);
 }
 
 void ScriptContext::onChangedScriptEnabled(const Reflection::PropertyDescriptor&)

--- a/Client/App/util/NormalId.cpp
+++ b/Client/App/util/NormalId.cpp
@@ -84,7 +84,7 @@ namespace RBX
 		return Vector3ToNormalId(m.getColumn(2));
 	}
 
-	NormalId inlinedFunction1(NormalId id)
+	NormalId normalIdToU(NormalId id)
 	{
 		switch (id)
 		{
@@ -106,22 +106,22 @@ namespace RBX
 		}
 	}
 
-	NormalId inlinedFunction2(NormalId id)
+	NormalId normalIdToV(NormalId id)
 	{
 		switch (id)
 		{
 		case NORM_X:
-			return NORM_Z;
+			return NORM_Y;
 		case NORM_Y:
-			return NORM_Y;
+			return NORM_Z;
 		case NORM_Z:
-			return NORM_Z;
-		case NORM_X_NEG:
-			return NORM_Z;
-		case NORM_Y_NEG:
 			return NORM_Y;
-		case NORM_Z_NEG:
+		case NORM_X_NEG:
+			return NORM_Y;
+		case NORM_Y_NEG:
 			return NORM_Z;
+		case NORM_Z_NEG:
+			return NORM_Y;
 		default:
 			RBXASSERT(0);
 			return NORM_Y;
@@ -180,8 +180,8 @@ namespace RBX
 		RBXASSERT(vInObject == uvwToObject(objectToUvw(vInObject, normalId), normalId));
 		RBXASSERT(wInObject == uvwToObject(objectToUvw(wInObject, normalId), normalId));
 
-		RBXASSERT(uInObject == normalIdToVector3(inlinedFunction1(normalId)));
-		RBXASSERT(vInObject == normalIdToVector3(inlinedFunction2(normalId)));
+		RBXASSERT(uInObject == normalIdToVector3(normalIdToU(normalId)));
+		RBXASSERT(vInObject == normalIdToVector3(normalIdToV(normalId)));
 		RBXASSERT(wInObject == normalIdToVector3(normalId));
 
 		return G3D::Matrix3(

--- a/Client/App/v8datamodel/Accoutrement.cpp
+++ b/Client/App/v8datamodel/Accoutrement.cpp
@@ -196,8 +196,7 @@ namespace RBX
 	{
 		if (PartInstance* handle = getHandle())
 		{
-			boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&Accoutrement::onEvent_HandleTouched, this, _1));
-			handleTouched = PartInstance::event_Touched.connect(handle, slot);
+			handleTouched = PartInstance::event_Touched.connect(handle, boost::bind(&Accoutrement::onEvent_HandleTouched, this, _1));
 		}
 		else
 		{

--- a/Client/App/v8datamodel/DataModel.cpp
+++ b/Client/App/v8datamodel/DataModel.cpp
@@ -44,9 +44,7 @@ namespace RBX
 
 	DataModel::~DataModel()
 	{
-		if (runService)
-			runService->Notifier<RunService, RunTransition>::removeListener(this);
-
+		Notifier<RunService, RunTransition>::disconnect(runService, this);
 		StandardOut::singleton()->print(MESSAGE_INFO, "~DataModel");
 	}
 

--- a/Client/App/v8datamodel/DebrisService.cpp
+++ b/Client/App/v8datamodel/DebrisService.cpp
@@ -69,6 +69,6 @@ namespace RBX
 
 		Instance::onServiceProvider(oldProvider, newProvider);
 
-		timer = newProvider ? newProvider->create<TimerService>() : NULL;
+		timer = ServiceProvider::create<TimerService>(newProvider);
 	}
 }

--- a/Client/App/v8datamodel/Explosion.cpp
+++ b/Client/App/v8datamodel/Explosion.cpp
@@ -109,22 +109,10 @@ namespace RBX
 
 	void Explosion::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
 	{
-		Listener<RunService, Stepped>* oldListener = this;
-
-		if (oldProvider)
-		{
-			if (RunService* runService = oldProvider->find<RunService>())
-				runService->Notifier<RunService, Stepped>::removeListener(oldListener);
-		}
+		Notifier<RunService, Stepped>::disconnect(ServiceProvider::find<RunService>(oldProvider), this);
 
 		Instance::onServiceProvider(oldProvider, newProvider);
 
-		Listener<RunService, Stepped>* newListener = this;
-
-		if (newProvider)
-		{
-			if (RunService* runService = newProvider->find<RunService>())
-				runService->Notifier<RunService, Stepped>::addListener(newListener);
-		}
+		Notifier<RunService, Stepped>::connect(ServiceProvider::find<RunService>(newProvider), this);
 	}
 }

--- a/Client/App/v8datamodel/Flag.cpp
+++ b/Client/App/v8datamodel/Flag.cpp
@@ -34,8 +34,7 @@ namespace RBX
 		{
 			if (PartInstance* handle = getHandle())
 			{
-				boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&Flag::onEvent_flagTouched, this, _1));
-				flagTouched = PartInstance::event_Touched.connect(handle, slot);
+				flagTouched = PartInstance::event_Touched.connect(handle, boost::bind(&Flag::onEvent_flagTouched, this, _1));
 			}
 		}
 	}

--- a/Client/App/v8datamodel/LocakBackpack.cpp
+++ b/Client/App/v8datamodel/LocakBackpack.cpp
@@ -6,8 +6,7 @@ namespace RBX
 
 	void LocalBackpackItem::onClick(const GuiEvent& event)
 	{
-		LocalBackpack* parent = static_cast<LocalBackpack*>(getParent());
-		RBXASSERT(fastDynamicCast<LocalBackpack>(getParent()) == parent);
+		LocalBackpack* parent = rbx_static_cast<LocalBackpack*>(getParent());
 
 		parent->onClick(this);
 	}
@@ -99,5 +98,109 @@ namespace RBX
 	void LocalBackpack::onClick(LocalBackpackItem* clickedItem)
 	{
 		pendingClick = shared_from(clickedItem->getItem());
+	}
+
+	void LocalBackpack::onLocalCharacterAdded(Instance* added)
+	{
+		localCharacter = shared_from(added);
+
+		Notifier<Instance, DescendentAdded>::connect(localCharacter, this);
+		Notifier<Instance, DescendentRemoving>::connect(localCharacter, this);
+	}
+
+	void LocalBackpack::onLocalPlayerAdded(Network::Player* added)
+	{
+		RBXASSERT(numChildren() == 0);
+		RBXASSERT(added);
+
+		localPlayer = shared_from(added);
+
+		Notifier<Instance, ChildAdded>::connect(localPlayer, this);
+		Notifier<Instance, ChildRemoved>::connect(localPlayer, this);
+		Notifier<Network::Player, Network::CharacterAdded>::connect(localPlayer, this);
+		Notifier<Network::Player, Network::CharacterRemoving>::connect(localPlayer, this);
+	}
+
+	void LocalBackpack::onLocalBackpackAdded(Backpack* added)
+	{
+		RBXASSERT(numChildren() <= 1);
+		RBXASSERT(added->getParent() == localPlayer.get());
+
+		localBackpack = shared_from(added);
+
+		Notifier<Instance, ChildAdded>::connect(localBackpack, this);
+		Notifier<Instance, ChildRemoved>::connect(localBackpack, this);
+	}
+
+	void LocalBackpack::clearAll()
+	{
+		clearLocalCharacter();
+		clearLocalPlayer();
+		clearLocalBackpack();
+
+		if (players)
+		{
+			Notifier<Instance, ChildAdded>::disconnect(players.get(), this);
+			Notifier<Instance, ChildRemoved>::disconnect(players.get(), this);
+
+			players.reset();
+		}
+	}
+
+	void LocalBackpack::clearLocalCharacter()
+	{
+		if (localCharacter)
+		{
+			Notifier<Instance, DescendentAdded>::disconnect(localCharacter, this);
+			Notifier<Instance, DescendentRemoving>::disconnect(localCharacter, this);
+
+			localCharacter.reset();
+		}
+	}
+
+	void LocalBackpack::clearLocalPlayer()
+	{
+		removeAllChildren();
+
+		if (localPlayer)
+		{
+			Notifier<Instance, ChildAdded>::disconnect(localPlayer, this);
+			Notifier<Instance, ChildRemoved>::disconnect(localPlayer, this);
+			Notifier<Network::Player, Network::CharacterAdded>::disconnect(localPlayer, this);
+			Notifier<Network::Player, Network::CharacterRemoving>::disconnect(localPlayer, this);
+
+			localPlayer.reset();
+		}
+	}
+
+	void LocalBackpack::clearLocalBackpack()
+	{
+		removeAllChildren();
+
+		if (localBackpack)
+		{
+			Notifier<Instance, ChildAdded>::disconnect(localBackpack, this);
+			Notifier<Instance, ChildRemoved>::disconnect(localBackpack, this);
+
+			localBackpack.reset();
+		}
+
+		lastRemovedIndex = -1;
+	}
+
+	void LocalBackpack::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
+	{
+		if (oldProvider)
+			clearAll();
+
+		Instance::onServiceProvider(oldProvider, newProvider);
+
+		if (newProvider)
+		{
+			players = shared_from(ServiceProvider::create<Network::Players>(this));
+
+			Notifier<Instance, ChildAdded>::connect(players, this);
+			Notifier<Instance, ChildRemoved>::connect(players, this);
+		}
 	}
 }

--- a/Client/App/v8datamodel/ModelInstance.cpp
+++ b/Client/App/v8datamodel/ModelInstance.cpp
@@ -275,7 +275,7 @@ namespace RBX
 	{
 		RBXASSERT(legacyOffset);
 
-		if (&(*getChildren()))
+		if (getChildren())
 		{
 			int count = (int)getChildren()->size();
 			if (count > 0)

--- a/Client/App/v8datamodel/Seat.cpp
+++ b/Client/App/v8datamodel/Seat.cpp
@@ -64,8 +64,7 @@ namespace RBX
 
 		if (!oldProvider)
 		{
-			boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&Seat::onEvent_seatTouched, this, _1));
-			seatTouched = PartInstance::event_Touched.connect(this, slot);
+			seatTouched = PartInstance::event_Touched.connect(this, boost::bind(&Seat::onEvent_seatTouched, this, _1));
 		}
 
 		if (!newProvider)

--- a/Client/App/v8datamodel/SpawnLocation.cpp
+++ b/Client/App/v8datamodel/SpawnLocation.cpp
@@ -23,21 +23,15 @@ namespace RBX
 		raisePropertyChanged(prop_TeamColor);
 	}
 
-	//99.81% match
-	//somehow stack usage in the DLL is less optimized
 	void SpawnLocation::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
 	{
 		Instance::onServiceProvider(oldProvider, newProvider);
-
-		if (!oldProvider)
-		{
-			boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&SpawnLocation::onEvent_spawnerTouched, this, _1));
-			spawnerTouched = PartInstance::event_Touched.connect(this, slot);
-		}
 		
 		if (!oldProvider)
 		{
-			SpawnerService* spawnerService = newProvider ? newProvider->create<SpawnerService>() : NULL;
+			spawnerTouched = PartInstance::event_Touched.connect(this, boost::bind(&SpawnLocation::onEvent_spawnerTouched, this, _1));
+
+			SpawnerService* spawnerService = ServiceProvider::create<SpawnerService>(newProvider);
 			RBXASSERT(spawnerService != NULL);
 
 			spawnerService->RegisterSpawner(this);
@@ -47,7 +41,7 @@ namespace RBX
 		{
 			spawnerTouched.disconnect();
 
-			SpawnerService* spawnerService = oldProvider ? oldProvider->create<SpawnerService>() : NULL;
+			SpawnerService* spawnerService = ServiceProvider::create<SpawnerService>(oldProvider);
 			RBXASSERT(spawnerService != NULL);
 
 			spawnerService->UnregisterSpawner(this);

--- a/Client/App/v8datamodel/Tool.cpp
+++ b/Client/App/v8datamodel/Tool.cpp
@@ -232,8 +232,7 @@ namespace RBX
 	{
 		if (PartInstance* handle = getHandle())
 		{
-			boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&Tool::onEvent_HandleTouched, this, _1));
-			handleTouched = PartInstance::event_Touched.connect(handle, slot);
+			handleTouched = PartInstance::event_Touched.connect(handle, boost::bind(&Tool::onEvent_HandleTouched, this, _1));
 		}
 		else
 		{

--- a/Client/App/v8datamodel/UserController.cpp
+++ b/Client/App/v8datamodel/UserController.cpp
@@ -82,14 +82,12 @@ namespace RBX
 		: runService(shared_from(ServiceProvider::create<RunService>(_controlledInstance))),
 		  controlledInstance(shared_from(_controlledInstance))
 	{
-		if (runService)
-			runService->Notifier<RunService, Heartbeat>::addListener(this);
+		runService->Notifier<RunService, Heartbeat>::connect(runService, this);
 	}
 
 	SteppingController::~SteppingController()
 	{
-		if (runService)
-			runService->Notifier<RunService, Heartbeat>::removeListener(this);
+		runService->Notifier<RunService, Heartbeat>::disconnect(runService, this);
 	}
 
 	PlayerController::PlayerController(ControllerService* _controllerService, const PVInstance* _controlledInstance)

--- a/Client/App/v8datamodel/Workspace.cpp
+++ b/Client/App/v8datamodel/Workspace.cpp
@@ -454,4 +454,27 @@ namespace RBX
 
 		insertItems(root.get(), items, insertMode, promptMode);
 	}
+
+	void Workspace::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
+	{
+		Notifier<RunService, Heartbeat>::disconnect(ServiceProvider::find<RunService>(oldProvider), this);
+
+		if (statsItem)
+		{
+			statsItem->setParent(NULL);
+			statsItem.reset();
+		}
+
+		Instance::onServiceProvider(oldProvider, newProvider);
+
+		scriptContext = ServiceProvider::create<ScriptContext>(newProvider);
+
+		if (Stats::Item* item = ServiceProvider::create<Stats::Item>(newProvider))
+		{
+			statsItem = Creatable::create<WorkspaceStatsItem>(this, world.get());
+			statsItem->setParent(item);
+		}
+
+		Notifier<RunService, Heartbeat>::connect(ServiceProvider::find<RunService>(newProvider), this);
+	}
 }

--- a/Client/App/v8tree/Instance.cpp
+++ b/Client/App/v8tree/Instance.cpp
@@ -113,7 +113,7 @@ namespace RBX
 
 	void Instance::onAddListener(Listener<Instance, ChildAdded>* listener) const
 	{
-		if (&(*children))
+		if (children)
 		{
 			boost::shared_ptr<const std::vector<boost::shared_ptr<Instance>>> c = children.read();
 			for (std::vector<boost::shared_ptr<Instance>>::const_iterator iter = c->begin(); iter != c->end(); iter++)
@@ -125,7 +125,7 @@ namespace RBX
 
 	void Instance::removeAllChildren()
 	{
-		while (&(*children))
+		while (children)
 		{
 			children->back()->setParent(NULL);
 		}
@@ -212,7 +212,7 @@ namespace RBX
 	{
 		typedef std::vector<boost::shared_ptr<Instance>>::const_iterator Iterator;
 
-		if (&(*children))
+		if (children)
 		{
 			boost::shared_ptr<const std::vector<boost::shared_ptr<Instance>>> r = children.read();
 
@@ -222,7 +222,7 @@ namespace RBX
 			}
 		}
 
-		event_ancestryChanged.fire(this, shared_from(event.oldParent));
+		event_ancestryChanged.fire(this, shared_from(event.child));
 		Notifier<Instance, AncestorChanged>::raise(event);
 	}
 
@@ -249,7 +249,7 @@ namespace RBX
 
 	int Instance::findChildIndex(const Instance* instance) const
 	{
-		RBXASSERT(&(*children));
+		RBXASSERT(children);
 
 		const std::vector<boost::shared_ptr<Instance>>& c = *children;
 
@@ -259,7 +259,7 @@ namespace RBX
 
 	void Instance::writeChildren(XmlElement* container)
 	{
-		if (&(*children))
+		if (children)
 		{
 			const std::vector<boost::shared_ptr<Instance>>& c = *children;
 
@@ -274,7 +274,7 @@ namespace RBX
 
 	Instance* Instance::findFirstChildByName(const std::string& findName) const
 	{
-		if (!&(*children))
+		if (!children)
 			return NULL;
 
 		const std::vector<boost::shared_ptr<Instance>>& c = *children;
@@ -294,7 +294,7 @@ namespace RBX
 		if (foundChild)
 			return foundChild;
 
-		if (!&(*children))
+		if (!children)
 			return NULL;
 
 		const std::vector<boost::shared_ptr<Instance>>& c = *children;

--- a/Client/App/v8tree/Service.cpp
+++ b/Client/App/v8tree/Service.cpp
@@ -50,7 +50,7 @@ namespace RBX
 
 	void ServiceProvider::onAddListener(Listener<ServiceProvider, ServiceAdded>* listener) const
 	{
-		if (&(*getChildren()))
+		if (getChildren())
 		{
 			std::vector<boost::shared_ptr<Instance>>::const_iterator end = getChildren()->end();
 			std::vector<boost::shared_ptr<Instance>>::const_iterator iter = getChildren()->begin();

--- a/Client/Network/Client.cpp
+++ b/Client/Network/Client.cpp
@@ -56,17 +56,11 @@ namespace RBX
 
 		void Client::onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider)
 		{
-			Listener<ServiceProvider, Closing>* oldListener = this;
-
-			if (oldProvider)
-			{
-				oldProvider->Notifier<ServiceProvider, Closing>::removeListener(oldListener);
-			}
+			Notifier<ServiceProvider, Closing>::disconnect(oldProvider, this);
 
 			if (oldProvider)
 			{
 				RunService* runService = oldProvider->find<RunService>();
-
 				if (runService)
 					runService->runDisabled = false;
 
@@ -84,17 +78,11 @@ namespace RBX
 				p->setConnection(rakPeer.get());
 
 				RunService* runService = newProvider->find<RunService>();
-
 				if (runService)
 					runService->runDisabled = true;
 			}
 
-			Listener<ServiceProvider, Closing>* newListener = this;
-
-			if (newProvider)
-			{
-				newProvider->Notifier<ServiceProvider, Closing>::addListener(newListener);
-			}
+			Notifier<ServiceProvider, Closing>::connect(newProvider, this);
 		}
 	}
 }

--- a/Client/Network/ClientPhysics.cpp
+++ b/Client/Network/ClientPhysics.cpp
@@ -2,6 +2,36 @@
 #include "NetworkSettings.h"
 #include "v8datamodel/PartInstance.h"
 
+//99.98% match
+bool areClose(const G3D::CoordinateFrame& c1, const G3D::CoordinateFrame& c2)
+{
+	if (fabs(c1.translation.x - c2.translation.x) > 0.2f)
+		return false;
+
+	if (fabs(c1.translation.y - c2.translation.y) > 0.2f)
+		return false;
+
+	if (fabs(c1.translation.z - c2.translation.z) > 0.2f)
+		return false;
+
+	for (int i = 0; i < 3; i++)
+	{
+		G3D::Vector3 v1, v2;
+
+		v1.x = c1.rotation[0][i];
+		v1.y = c1.rotation[1][i];
+		v1.z = c1.rotation[2][i];
+		v2.x = c2.rotation[0][i];
+		v2.y = c2.rotation[1][i];
+		v2.z = c2.rotation[2][i];
+
+		if ((v1 - v2).squaredMagnitude() > 0.010000001f)
+			return false;
+	}
+
+	return true;
+}
+
 namespace RBX
 {
 	namespace Network
@@ -9,6 +39,19 @@ namespace RBX
 		ClientPhysics::ClientPhysics(PartInstance* part)
 			: part(part)
 		{
+		}
+
+		ClientPhysics::~ClientPhysics()
+		{
+			Notifier<RunService, Heartbeat>::disconnect(runService.lock(), this);
+		}
+
+		void ClientPhysics::sleep()
+		{
+			Notifier<RunService, Heartbeat>::disconnect(runService.lock(), this);
+			runService.reset();
+
+			lastPos = part->getCoordinateFrame();
 		}
 
 		void ClientPhysics::onEvent(const RunService* source, Heartbeat event)
@@ -19,6 +62,30 @@ namespace RBX
 				sleep();
 			else
 				RBXASSERT(0);
+		}
+
+		void ClientPhysics::update(const boost::shared_ptr<RunService>& runService)
+		{
+			lastUpdateTime = G3D::System::getLocalTime();
+
+			const G3D::CoordinateFrame& cframe = part->getCoordinateFrame();
+
+			if (areClose(lastPos, cframe))
+			{
+				sleep();
+				return;
+			}
+
+			lastPos = cframe;
+
+			if (this->runService.lock() != runService)
+			{
+				Notifier<RunService, Heartbeat>::disconnect(this->runService.lock(), this);
+
+				this->runService = runService;
+
+				Notifier<RunService, Heartbeat>::connect(this->runService.lock(), this);
+			}
 		}
 	}
 }

--- a/Client/Network/ClientPhysics.h
+++ b/Client/Network/ClientPhysics.h
@@ -19,7 +19,7 @@ namespace RBX
 
 		public:
 			ClientPhysics(PartInstance* part);
-			void update(const boost::shared_ptr<RunService>&);
+			void update(const boost::shared_ptr<RunService>& runService);
 			void sleep();
 			virtual ~ClientPhysics();
 		protected:

--- a/Client/Network/IdManager.cpp
+++ b/Client/Network/IdManager.cpp
@@ -28,8 +28,7 @@ namespace RBX
 	{
 		if (newProvider)
 		{
-			boost::slot<boost::function<void(boost::shared_ptr<Instance>)>> slot(boost::bind(&IdManager::removeInstance, this, _1));
-			removeInstanceConnection = event_descendentRemoving.connect(getRootAncestor(), slot);
+			removeInstanceConnection = event_descendentRemoving.connect(getRootAncestor(), boost::bind(&IdManager::removeInstance, this, _1));
 		}
 	}
 }

--- a/Client/Network/Players.cpp
+++ b/Client/Network/Players.cpp
@@ -285,7 +285,7 @@ namespace RBX
 			if (backendProcessing(this, false))
 				event_PlayerRemoving.fire(this, shared_from(player));
 
-			player->Notifier<Player, CharacterAdded>::removeListener(this);
+			Notifier<Player, CharacterAdded>::disconnect(player, this);
 		}
 
 		void AbuseReport::addMessage(const ChatMessage& cm)

--- a/Client/Network/Server.cpp
+++ b/Client/Network/Server.cpp
@@ -62,7 +62,7 @@ namespace RBX
 
 		int Server::getClientCount()
 		{
-			if (&(*getChildren()))
+			if (getChildren())
 			{
 				return std::count_if(getChildren()->begin(), getChildren()->end(), &isReplicator);
 			}


### PR DESCRIPTION
- Match several functions that use addListener/removeListener from Notifier with Notifier::connect/disconnect, functions whose signatures appear in a (weirdly) unallocated section of version 0.3.719.0 and 0.3.720.0's PDBs
- Corrected operator function in CopyOnWrite
- Removed all instances of boost::slots being explicitly created (see changes), this also improves matches