### PR TITLE
Proper obj splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ FodyWeavers.xsd
 
 # objdiff stuff
 objdiff.json
+
+orig/*
+!orig/.gitkeep

--- a/configure.py
+++ b/configure.py
@@ -1,82 +1,62 @@
 import json
-import argparse
 from pathlib import Path
-import urllib.request
-import subprocess
-import os
+
+from tools.project import (
+    delinkObjs,
+    Object,
+    NonMatching,
+    Matching,
+)
 
 root = Path(__file__).parent
+obj_dir = root / "obj"
+app_obj_dir = root / "Client/App/obj/ReleaseAssert"
+glg3d_obj_dir = root / "Client/Rendering/g3d/obj/GLG3D/Release"
 
-delink_release_link = "https://github.com/HaydnTrigg/delink/releases/download/v0.15.0/delink-windows-x86_64.exe"
-delink_local_path = root / "tools/delink.exe"
-webservice_dll_location = root / "orig/WebService.dll"
-webservice_pdb_location = root / "orig/WebService.pdb"
-out_dir = root / "obj"
 
 objs = [
-    [
-        out_dir / "0210_Ball.obj",
-        root / "Client/App/obj/ReleaseAssert/Ball.obj",
-        "./obj/ReleaseAssert/Ball.obj"
-    ],
-    [
-        out_dir / "0211_Block.obj",
-        root / "Client/App/obj/ReleaseAssert/Block.obj",
-        "./obj/ReleaseAssert/Block.obj"
-    ]
+    Object(NonMatching, obj_dir / "0018_DDSTexture.obj", glg3d_obj_dir / "DDSTexture.obj", "./obj/glg3d/release/DDSTexture.obj"),
+    Object(NonMatching, obj_dir / "0019_Draw.obj", glg3d_obj_dir / "Draw.obj", "./obj/glg3d/release/Draw.obj"),
+    Object(NonMatching, obj_dir / "0020_DXCaps.obj", glg3d_obj_dir / "DXCaps.obj", "./obj/glg3d/release/DXCaps.obj"),
+    Object(NonMatching, obj_dir / "0021_getOpenGLState.obj", glg3d_obj_dir / "getOpenGLState.obj", "./obj/glg3d/release/getOpenGLState.obj"),
+    Object(NonMatching, obj_dir / "0022_GFont.obj", glg3d_obj_dir / "GFont.obj", "./obj/glg3d/release/GFont.obj"),
+    Object(NonMatching, obj_dir / "0023_glcalls.obj", glg3d_obj_dir / "glcalls.obj", "./obj/glg3d/release/glcalls.obj"),
+    Object(NonMatching, obj_dir / "0024_GLCaps.obj", glg3d_obj_dir / "GLCaps.obj", "./obj/glg3d/release/GLCaps.obj"),
+    Object(NonMatching, obj_dir / "0025_glenumtostring.obj", glg3d_obj_dir / "glenumtostring.obj", "./obj/glg3d/release/glenumtostring.obj"),
+    Object(NonMatching, obj_dir / "0026_GPUProgram.obj", glg3d_obj_dir / "GPUProgram.obj", "./obj/glg3d/release/GPUProgram.obj"),
+    Object(NonMatching, obj_dir / "0027_GWindow.obj", glg3d_obj_dir / "GWindow.obj", "./obj/glg3d/release/GWindow.obj"),
+    Object(NonMatching, obj_dir / "0028_LightingParameters.obj", glg3d_obj_dir / "LightingParameters.obj", "./obj/glg3d/release/LightingParameters.obj"),
+    Object(NonMatching, obj_dir / "0029_Milestone.obj", glg3d_obj_dir / "Milestone.obj", "./obj/glg3d/release/Milestone.obj"),
+    Object(NonMatching, obj_dir / "0030_RenderDevice.obj", glg3d_obj_dir / "RenderDevice.obj", "./obj/glg3d/release/RenderDevice.obj"),
+    Object(NonMatching, obj_dir / "0031_Shader.obj", glg3d_obj_dir / "Shader.obj", "./obj/glg3d/release/Shader.obj"),
+    Object(NonMatching, obj_dir / "0032_Sky.obj", glg3d_obj_dir / "Sky.obj", "./obj/glg3d/release/Sky.obj"),
+    Object(NonMatching, obj_dir / "0033_Texture.obj", glg3d_obj_dir / "Texture.obj", "./obj/glg3d/release/Texture.obj"),
+    Object(NonMatching, obj_dir / "0034_TextureFormat.obj", glg3d_obj_dir / "TextureFormat.obj", "./obj/glg3d/release/TextureFormat.obj"),
+    Object(NonMatching, obj_dir / "0035_TextureManager.obj", glg3d_obj_dir / "TextureManager.obj", "./obj/glg3d/release/TextureManager.obj"),
+    Object(NonMatching, obj_dir / "0036_ToneMap.obj", glg3d_obj_dir / "ToneMap.obj", "./obj/glg3d/release/ToneMap.obj"),
+    Object(NonMatching, obj_dir / "0037_VAR.obj", glg3d_obj_dir / "VAR.obj", "./obj/glg3d/release/VAR.obj"),
+    Object(NonMatching, obj_dir / "0038_VARArea.obj", glg3d_obj_dir / "VARArea.obj", "./obj/glg3d/release/VARArea.obj"),
+    Object(NonMatching, obj_dir / "0039_Win32Window.obj", glg3d_obj_dir / "Win32Window.obj", "./obj/glg3d/release/Win32Window.obj"),
+
+    Object(Matching, obj_dir / "0210_Ball.obj", app_obj_dir / "Ball.obj", "./obj/releaseassert/Ball.obj"),
+    Object(NonMatching, obj_dir / "0211_Block.obj", app_obj_dir / "Block.obj", "./obj/releaseassert/Block.obj"),
 ]
 
 
-def delinkObjs():
-    if (Path(out_dir).is_dir()):
-        return
-
-    if not Path(webservice_dll_location).is_file() or not Path(webservice_pdb_location).is_file():
-        raise Exception("Please put WebService.dll and WebService.pdb in the orig folder!")
-
-    if not Path(root / "tools").is_dir():
-        os.makedirs("tools")
-
-    if not Path(delink_local_path).is_file():
-        urllib.request.urlretrieve(delink_release_link, delink_local_path)
-
-    command = "{delink} pe-split {WebServiceLocation} --pdb {PDBLocation} --outdir {out}".format(
-        delink=delink_local_path,
-        WebServiceLocation=webservice_dll_location,
-        PDBLocation=webservice_pdb_location,
-        out=out_dir
-    )
-    p = subprocess.Popen(command)
-    p.wait()
-
-
 def configure():
-    basePath = root / "Client/App/obj/ReleaseAssert"
-    
-    # TODO: categorize objects by which folder theyre in
+    delinkObjs(root, obj_dir)
     config = {
         "$schema": "https://raw.githubusercontent.com/encounter/objdiff/main/config.schema.json",
         "build_base": False,
         "units": [],
     }
-    
+
     with open("objdiff.json", "w", encoding='utf-8') as file:
-        for i, object in enumerate(objs):
-
-            print(str(objs[i][0]))
-
-            config["units"].append({
-                "name": str(objs[i][2]),
-                "target_path": str(objs[i][0])
-            })
-
-            if objs[i][1].is_file():
-                config["units"][i].update({
-                    "base_path": str(objs[i][1])
-                })
+        for object in objs:
+            config["units"].append(object.toUnitObject())
 
         json.dump(config, file, indent=4)
 
+
 if __name__ == "__main__":
-    delinkObjs()
     configure()

--- a/configure.py
+++ b/configure.py
@@ -1,19 +1,57 @@
 import json
 import argparse
 from pathlib import Path
+import urllib.request
+import subprocess
+import os
 
 root = Path(__file__).parent
 
-parser = argparse.ArgumentParser()
-parser.add_argument("targetPath", help="The directory to your target object files.")
+delink_release_link = "https://github.com/HaydnTrigg/delink/releases/download/v0.15.0/delink-windows-x86_64.exe"
+delink_local_path = root / "tools/delink.exe"
+webservice_dll_location = root / "orig/WebService.dll"
+webservice_pdb_location = root / "orig/WebService.pdb"
+out_dir = root / "obj"
 
-def configure(desiredTargetPath):
-    targetPath = root / desiredTargetPath
-    basePath = root / "Client/App/obj/ReleaseAssert"
+objs = [
+    [
+        out_dir / "0210_Ball.obj",
+        root / "Client/App/obj/ReleaseAssert/Ball.obj",
+        "./obj/ReleaseAssert/Ball.obj"
+    ],
+    [
+        out_dir / "0211_Block.obj",
+        root / "Client/App/obj/ReleaseAssert/Block.obj",
+        "./obj/ReleaseAssert/Block.obj"
+    ]
+]
 
-    if not targetPath.is_dir():
-        print("Specified target directory does not exist.")
+
+def delinkObjs():
+    if (Path(out_dir).is_dir()):
         return
+
+    if not Path(webservice_dll_location).is_file() or not Path(webservice_pdb_location).is_file():
+        raise Exception("Please put WebService.dll and WebService.pdb in the orig folder!")
+
+    if not Path(root / "tools").is_dir():
+        os.makedirs("tools")
+
+    if not Path(delink_local_path).is_file():
+        urllib.request.urlretrieve(delink_release_link, delink_local_path)
+
+    command = "{delink} pe-split {WebServiceLocation} --pdb {PDBLocation} --outdir {out}".format(
+        delink=delink_local_path,
+        WebServiceLocation=webservice_dll_location,
+        PDBLocation=webservice_pdb_location,
+        out=out_dir
+    )
+    p = subprocess.Popen(command)
+    p.wait()
+
+
+def configure():
+    basePath = root / "Client/App/obj/ReleaseAssert"
     
     # TODO: categorize objects by which folder theyre in
     config = {
@@ -21,25 +59,24 @@ def configure(desiredTargetPath):
         "build_base": False,
         "units": [],
     }
-
-    objects = list(f for f in targetPath.iterdir() if f.is_file())
     
     with open("objdiff.json", "w", encoding='utf-8') as file:
-        for i, targetObj in enumerate(objects):
-            objName = targetObj.name
+        for i, object in enumerate(objs):
+
+            print(str(objs[i][0]))
 
             config["units"].append({
-                "name": targetObj.stem,
-                "target_path": str(targetPath / objName)
+                "name": str(objs[i][2]),
+                "target_path": str(objs[i][0])
             })
 
-            if basePath.joinpath(objName).is_file():
+            if objs[i][1].is_file():
                 config["units"][i].update({
-                    "base_path": str(basePath / objName)
+                    "base_path": str(objs[i][1])
                 })
 
         json.dump(config, file, indent=4)
 
 if __name__ == "__main__":
-    args = parser.parse_args()
-    configure(args.targetPath)
+    delinkObjs()
+    configure()

--- a/tools/project.py
+++ b/tools/project.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import urllib.request
+import subprocess
+import os
+
+Matching = True
+Equivalent = False
+NonMatching = False
+
+
+def delinkObjs(root, obj_dir):
+    delink_release_link = "https://github.com/HaydnTrigg/delink/releases/download/v0.15.0/delink-windows-x86_64.exe"
+    delink_local_path = root / "tools/delink.exe"
+    webservice_dll_location = root / "orig/WebService.dll"
+    webservice_pdb_location = root / "orig/WebService.pdb"
+
+    if (Path(obj_dir).is_dir()):
+        return
+
+    if not Path(webservice_dll_location).is_file() or not Path(webservice_pdb_location).is_file():
+        raise Exception("Please put WebService.dll and WebService.pdb in the orig folder!")
+
+    if not Path(root / "tools").is_dir():
+        os.makedirs("tools")
+
+    if not Path(delink_local_path).is_file():
+        urllib.request.urlretrieve(delink_release_link, delink_local_path)
+
+    command = "{delink} pe-split {WebServiceLocation} --pdb {PDBLocation} --outdir {out}".format(
+        delink=delink_local_path,
+        WebServiceLocation=webservice_dll_location,
+        PDBLocation=webservice_pdb_location,
+        out=obj_dir
+    )
+    subprocess.Popen(command).wait()
+
+
+class Object:
+    def __init__(self, matching, target_path, base_path, pdb_path):
+        self.matching = matching
+        self.target_path = Path(target_path)
+        self.base_path = Path(base_path)
+        self.pdb_path = pdb_path
+
+    def toUnitObject(self) -> dict:
+        ret = {
+            "name": self.pdb_path,
+            "target_path": str(self.target_path),
+        }
+
+        if self.base_path.is_file():
+            ret["base_path"] = str(self.base_path)
+
+        ret["metadata"] = {
+            "complete": self.matching
+        }
+        return ret


### PR DESCRIPTION
This pr adds proper obj splitting using delink (no more Ghidra export 🎉)

Still currently a draft since I need to add all the objs and optimize everything but it works:

<img width="1749" height="891" alt="image" src="https://github.com/user-attachments/assets/00d507fe-26a1-42f3-896d-884355b8bfd3" />

the only thing is that some data is stored in shared_data.obj due to how delink works, but this is still WAYYYY better than the old method

Also closes #131