### PR TITLE
Remove fastDynamicCast, inlined Instance templates

### DIFF
--- a/Client/App/gui/GUI.cpp
+++ b/Client/App/gui/GUI.cpp
@@ -23,11 +23,21 @@ namespace RBX
 		setName("Unnamed GuiItem");
 	}
 
+	const GuiItem* GuiItem::getGuiItem(int index) const
+	{
+		return dynamic_cast<const GuiItem*>(getChild(index));
+	}
+
+	GuiItem* GuiItem::getGuiItem(int index)
+	{
+		return dynamic_cast<GuiItem*>(getChild(index));
+	}
+
 	GuiResponse GuiItem::processNonFocus(const GuiEvent& event)
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			GuiItem* current = fastDynamicCast<GuiItem>(getChild(i));
+			GuiItem* current = getGuiItem((int)i);
 
 			if (current && current != focus.get())
 			{
@@ -63,7 +73,7 @@ namespace RBX
 
 	const GuiItem* GuiItem::getGuiParent() const
 	{
-		return fastDynamicCast<const GuiItem>(getParent());
+		return dynamic_cast<const GuiItem*>(getParent());
 	}
 	
 	GuiResponse GuiItem::process(const GuiEvent& event)
@@ -104,7 +114,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			const GuiItem* current = fastDynamicCast<const GuiItem>(getChild(i));
+			const GuiItem* current = getGuiItem((int)i);
 
 			if (current)
 			{
@@ -137,7 +147,7 @@ namespace RBX
 
 			for (size_t i = 0; i < numChildren(); i++)
 			{
-				GuiItem* current = fastDynamicCast<GuiItem>(getChild(i));
+				GuiItem* current = getGuiItem((int)i);
 				if (current)
 					current->render2d(adorn);
 			}
@@ -193,7 +203,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			GuiItem* current = fastDynamicCast<GuiItem>(getChild(i));
+			GuiItem* current = getGuiItem((int)i);
 			if (current)
 				current->render2d(adorn);
 		}

--- a/Client/App/humanoid/Humanoid.cpp
+++ b/Client/App/humanoid/Humanoid.cpp
@@ -76,7 +76,7 @@ namespace RBX
 	{
 		if (humanoid)
 		{
-			if (ModelInstance* character = fastDynamicCast<ModelInstance>(humanoid->getParent()))
+			if (ModelInstance* character = dynamic_cast<ModelInstance*>(humanoid->getParent()))
 				return character;
 		}
 
@@ -380,7 +380,7 @@ namespace RBX
 
 	static void breakJoints(Instance* instance)
 	{
-		PartInstance* part = Instance::fastDynamicCast<PartInstance>(instance);
+		PartInstance* part = dynamic_cast<PartInstance*>(instance);
 		if (!part)
 			instance->for_eachChild(&breakJoints);
 		else
@@ -425,7 +425,7 @@ namespace RBX
 
 	void Humanoid::moveTo2(G3D::Vector3 worldPosition, boost::shared_ptr<Instance> part)
 	{
-		PartInstance* p = fastDynamicCast<PartInstance>(part.get());
+		PartInstance* p = dynamic_cast<PartInstance*>(part.get());
 		if (!p)
 			throw std::runtime_error("Argument error: A Part is required");
 
@@ -623,7 +623,7 @@ namespace RBX
 		{
 			PartInstance* part = PartInstance::fromPrimitive(primitives[i]);
 
-			if (!fastDynamicCast<Tool>(part->getParent()))
+			if (!dynamic_cast<Tool*>(part->getParent()))
 			{
 				part->setAlphaModifier(alphaModifier);
 			}

--- a/Client/App/include/gui/Gui.h
+++ b/Client/App/include/gui/Gui.h
@@ -22,7 +22,7 @@ namespace RBX
 		virtual void onDescendentRemoving(const boost::shared_ptr<Instance>& instance);
 		virtual bool askAddChild(const Instance* instance) const
 		{
-			return fastDynamicCast<const GuiItem>(instance) != NULL;
+			return dynamic_cast<const GuiItem*>(instance) != NULL;
 		}
 		virtual const Name& getClassName() const
 		{
@@ -104,8 +104,8 @@ namespace RBX
 		const G3D::Vector2& getGuiSize() const;
 		__declspec(noinline) const GuiItem* getGuiParent() const;
 		GuiItem* getGuiParent();
-		const GuiItem* getGuiItem(int) const;
-		GuiItem* getGuiItem(int);
+		const GuiItem* getGuiItem(int index) const;
+		GuiItem* getGuiItem(int index);
 
 	public:
 		static const G3D::Color4& enabledFill();

--- a/Client/App/include/gui/Layout.h
+++ b/Client/App/include/gui/Layout.h
@@ -21,8 +21,9 @@ namespace RBX
 		G3D::Color4 backdropColor;
 
 	public:
-		Layout() // TODO: this constructor is a guess based on another function that uses Layout class (RelativePanel ctor). is this correct?
+		Layout()
 			: backdropColor(G3D::Color4::clear()),
+			  offset(0, 0),
 			  layoutStyle(HORIZONTAL),
 			  xLocation(Rect::LEFT),
 			  yLocation(Rect::TOP)

--- a/Client/App/include/util/Debug.h
+++ b/Client/App/include/util/Debug.h
@@ -19,11 +19,6 @@ namespace RBX
 	public:
 		virtual void dump(std::ostream& stream);
 
-	/* public:
-		Debugable(const Debugable&);
-		Debugable();
-		Debugable& operator=(const Debugable&); */
-
 	public:
 		static void forceBadTypeId();
 		static void doCrash();
@@ -31,16 +26,13 @@ namespace RBX
 	};
 }
 
-//#define RBXASSERT(expr) if ( RBX::Debugable::assertAction == Debugable::CrashOnAssert && !(expr)) RBX::Debugable::doCrash()
-// copied from assert.h
-//#define RBXASSERT(expr) (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) )
 #define SCOPED(expr) do \
 	{ \
 		expr; \
 	} \
 	while (0)
 #if defined(_DEBUG) || defined(_RELEASEASSERT)
-#define RBXASSERT(expr) SCOPED( (void)( ( RBX::Debugable::assertAction != RBX::Debugable::CrashOnAssert || !!(expr) ) || (RBX::Debugable::doCrash(), 0) ) )
+#define RBXASSERT(expr) SCOPED( if ( RBX::Debugable::assertAction == RBX::Debugable::CrashOnAssert && !(expr) ) RBX::Debugable::doCrash(); )
 #else
 #define RBXASSERT(expr)
 #endif
@@ -50,6 +42,6 @@ namespace RBX
 template <typename To, typename From>
 To rbx_static_cast(From u)
 {
-	RBXASSERT(static_cast<From>(dynamic_cast<To>(u)) == u);
+	RBXASSERT(dynamic_cast<To>(u) == u);
 	return static_cast<To>(u);
 }

--- a/Client/App/include/v8datamodel/GlobalSettings.h
+++ b/Client/App/include/v8datamodel/GlobalSettings.h
@@ -18,7 +18,7 @@ namespace RBX
 		protected:
 			virtual bool askAddChild(const Instance* instance) const
 			{
-				return fastDynamicCast<const GlobalSettings::Item>(instance) != NULL;
+				return dynamic_cast<const GlobalSettings::Item*>(instance) != NULL;
 			}
 		};
 

--- a/Client/App/include/v8datamodel/JointsService.h
+++ b/Client/App/include/v8datamodel/JointsService.h
@@ -22,7 +22,7 @@ namespace RBX
 
 		virtual bool askAddChild(const Instance* instance) const
 		{
-			return fastDynamicCast<const JointInstance>(instance) != NULL;
+			return dynamic_cast<const JointInstance*>(instance) != NULL;
 		}
 
 		virtual XmlElement* write()

--- a/Client/App/include/v8datamodel/PVInstance.h
+++ b/Client/App/include/v8datamodel/PVInstance.h
@@ -103,7 +103,7 @@ namespace RBX
 		PVInstance* getTopLevelPVParent();
 		bool isTopLevelPVInstance() const
 		{
-			return !fastDynamicCast<PVInstance>(getParent()) || getTypedRoot<PVInstance>() == rbx_static_cast<PVInstance*>(getParent());
+			return !queryTypedParent<PVInstance>() || getTypedRoot<PVInstance>() == getTypedParent<PVInstance>();
 		}
 		void setPVGridOffsetLegacy(const G3D::CoordinateFrame& _offset);
 		G3D::CoordinateFrame* getLegacyOffset()

--- a/Client/App/include/v8tree/Instance.h
+++ b/Client/App/include/v8tree/Instance.h
@@ -380,10 +380,63 @@ namespace RBX
 		}
 
 		template<typename Type>
-		const Type* getTypedParent() const;
+		const Type* getTypedParent() const
+		{
+			return rbx_static_cast<const Type*>(parent);
+		}
 
 		template<typename Type>
-		const Type* getTypedRoot() const;
+		Type* getTypedParent()
+		{
+			return rbx_static_cast<Type*>(parent);
+		}
+
+		template<typename Type>
+		const Type* getTypedChild(int index) const
+		{
+			return rbx_static_cast<const Type*>((*children)[index].get());
+		}
+
+		template<typename Type>
+		Type* getTypedChild(int index)
+		{
+			return rbx_static_cast<Type*>((*children)[index].get());
+		}
+
+		template<typename Type>
+		const Type* getTypedRoot() const
+		{
+			RBXASSERT(dynamic_cast<const Type*>(this));
+			const Type* typedParent = dynamic_cast<const Type*>(parent);
+			if (typedParent)
+				return typedParent->getTypedRoot<Type>();
+			else
+				return static_cast<const Type*>(this);
+		}
+
+		template<typename Type>
+		const Type* queryTypedParent() const
+		{
+			return dynamic_cast<Type*>(parent);
+		}
+
+		template<typename Type>
+		Type* queryTypedParent()
+		{
+			return dynamic_cast<Type*>(parent);
+		}
+
+		template<typename Type>
+		const Type* queryTypedChild(int index) const
+		{
+			return dynamic_cast<const Type*>((*children)[index].get());
+		}
+
+		template<typename Type>
+		Type* queryTypedChild(int index)
+		{
+			return dynamic_cast<Type*>((*children)[index].get());
+		}
 
 		template<typename Type>
 		Type* findFirstChildOfType() const;
@@ -416,18 +469,6 @@ namespace RBX
 		static void signalDescendentAdded(Instance* instance, Instance* beginParent, Instance* oldParent);
 		static void signalDescendentRemoving(const boost::shared_ptr<Instance>& instance, Instance* beginParent, Instance* newParent);
 	public:
-		// NOTE: This is entirely inlined. See assertions in later client builds.
-		template<typename To>
-		static To* fastDynamicCast(Instance* instance)
-		{
-			return dynamic_cast<To*>(instance);
-		}
-
-		template<typename To>
-		static To* fastDynamicCast(const Instance* instance)
-		{
-			return dynamic_cast<To*>(instance);
-		}
 
 		// TODO: remove the __forceinline
 		template<typename Class>
@@ -436,7 +477,7 @@ namespace RBX
 			Instance* p = instance;
 			while (p != NULL)
 			{
-				Class* castedInstance = fastDynamicCast<Class>(p);
+				Class* castedInstance = dynamic_cast<Class*>(p);
 				if (castedInstance)
 					return castedInstance;
 

--- a/Client/App/include/v8tree/Service.h
+++ b/Client/App/include/v8tree/Service.h
@@ -79,7 +79,7 @@ namespace RBX
 		{
 			while (context != NULL)
 			{
-				if (const ServiceProvider* s = fastDynamicCast<const ServiceProvider>(context))
+				if (const ServiceProvider* s = dynamic_cast<const ServiceProvider*>(context))
 					return s;
 
 				context = context->getParent();

--- a/Client/App/tool/DragUtilities.cpp
+++ b/Client/App/tool/DragUtilities.cpp
@@ -64,7 +64,7 @@ namespace RBX
 
 	void DragUtilities::getPrimitivesConst(const Instance* instance, std::vector<const Primitive*>& primitives)
 	{
-		const PartInstance* partInstance = Instance::fastDynamicCast<const PartInstance>(instance);
+		const PartInstance* partInstance = dynamic_cast<const PartInstance*>(instance);
 
 		if (partInstance)
 			primitives.push_back(partInstance->getPrimitive());

--- a/Client/App/tool/ToolsArrow.cpp
+++ b/Client/App/tool/ToolsArrow.cpp
@@ -70,8 +70,8 @@ namespace RBX
 
 		for (size_t i = 0; i < workspace->numChildren(); i++)
 		{
-			ILocation* location = Instance::fastDynamicCast<ILocation>(workspace->getChild(i));
-			ISelectable3d* selectable3d = Instance::fastDynamicCast<ISelectable3d>(workspace->getChild(i));
+			ILocation* location = workspace->queryTypedChild<ILocation>((int)i);
+			ISelectable3d* selectable3d = workspace->queryTypedChild<ISelectable3d>((int)i);
 
 			if (location && selectable3d)
 			{

--- a/Client/App/util/RunStateOwner.cpp
+++ b/Client/App/util/RunStateOwner.cpp
@@ -86,7 +86,7 @@ namespace RBX
 	{
 		RBXASSERT(!runThread);
 
-		boost::shared_ptr<DataModel> dataModel = shared_from(fastDynamicCast<DataModel>(getParent()));
+		boost::shared_ptr<DataModel> dataModel = shared_from(dynamic_cast<DataModel*>(getParent()));
 		runThread.reset(new boost::thread(background_function(boost::bind(&RunService::runProc, shared_from(this), dataModel), "rbx_runProc")));
 	}
 }

--- a/Client/App/v8datamodel/Accoutrement.cpp
+++ b/Client/App/v8datamodel/Accoutrement.cpp
@@ -112,7 +112,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			if (ICameraSubject* subject = fastDynamicCast<ICameraSubject>(getChild(i)))
+			if (ICameraSubject* subject = queryTypedChild<ICameraSubject>((int)i))
 				subject->onCameraNear(distance);
 		}
 	}
@@ -121,7 +121,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			if (IRenderable* renderable = fastDynamicCast<IRenderable>(getChild(i)))
+			if (IRenderable* renderable = queryTypedChild<IRenderable>((int)i))
 				renderable->render3dSelect(adorn, selectState);
 		}
 	}

--- a/Client/App/v8datamodel/Camera.cpp
+++ b/Client/App/v8datamodel/Camera.cpp
@@ -43,14 +43,14 @@ namespace RBX
 
 	bool Camera::askSetParent(const Instance* instance) const
 	{
-		return fastDynamicCast<const Workspace>(instance) != NULL;
+		return dynamic_cast<const Workspace*>(instance) != NULL;
 	}
 
 	ICameraOwner* Camera::getCameraOwner()
 	{
 		for (Instance* instance = getParent(); instance != NULL; instance = instance->getParent())
 		{
-			ICameraOwner* cameraOwner = fastDynamicCast<ICameraOwner>(instance);
+			ICameraOwner* cameraOwner = dynamic_cast<ICameraOwner*>(instance);
 			if (cameraOwner)
 				return cameraOwner;
 		}
@@ -153,7 +153,7 @@ namespace RBX
 		Instance* instance = getCameraSubjectInstance();
 		if (instance)
 		{
-			ICameraSubject* subject = fastDynamicCast<ICameraSubject>(instance);
+			ICameraSubject* subject = dynamic_cast<ICameraSubject*>(instance);
 			RBXASSERT(subject);
 			cameraFocus = subject->getLocation();
 		}
@@ -282,7 +282,7 @@ namespace RBX
 		Instance* instance = getCameraSubjectInstance();
 		if (instance)
 		{
-			ICameraSubject* subject = fastDynamicCast<ICameraSubject>(instance);
+			ICameraSubject* subject = dynamic_cast<ICameraSubject*>(instance);
 			RBXASSERT(subject);
 			return subject;
 		}
@@ -318,7 +318,7 @@ namespace RBX
 	{
 		if (newSubject != getCameraSubjectInstance())
 		{
-			if (fastDynamicCast<ICameraSubject>(newSubject))
+			if (dynamic_cast<ICameraSubject*>(newSubject))
 			{
 				cameraSubject = shared_from((ModelInstance*) newSubject);
 				raisePropertyChanged(cameraSubjectProp);

--- a/Client/App/v8datamodel/CharacterAppearance.cpp
+++ b/Client/App/v8datamodel/CharacterAppearance.cpp
@@ -16,7 +16,7 @@ namespace RBX
 
 	bool CharacterAppearance::askSetParent(const Instance* instance) const
 	{
-		return fastDynamicCast<const ModelInstance>(instance) != NULL;
+		return dynamic_cast<const ModelInstance*>(instance) != NULL;
 	}
 
 	ShirtGraphic::ShirtGraphic()

--- a/Client/App/v8datamodel/DataModel.cpp
+++ b/Client/App/v8datamodel/DataModel.cpp
@@ -57,7 +57,7 @@ namespace RBX
 
 	bool DataModel::askAddChild(const Instance* instance) const
 	{
-		return fastDynamicCast<const Service>(instance) != NULL;
+		return dynamic_cast<const Service*>(instance) != NULL;
 	}
 
 	boost::shared_ptr<DataModel> DataModel::createDataModel()

--- a/Client/App/v8datamodel/FaceInstance.cpp
+++ b/Client/App/v8datamodel/FaceInstance.cpp
@@ -30,6 +30,6 @@ namespace RBX
 
 	bool FaceInstance::askSetParent(const Instance* instance) const 
 	{
-		return fastDynamicCast<const PartInstance>(instance) != NULL;
+		return dynamic_cast<const PartInstance*>(instance) != NULL;
 	}
 }

--- a/Client/App/v8datamodel/Feature.cpp
+++ b/Client/App/v8datamodel/Feature.cpp
@@ -58,7 +58,7 @@ namespace RBX
 	// TODO: 98.92% match
 	bool Feature::getRenderCoord(G3D::CoordinateFrame& c) const
 	{
-		PartInstance* part = fastDynamicCast<PartInstance>(getParent());
+		PartInstance* part = dynamic_cast<PartInstance*>(getParent());
 
 		if (part)
 		{
@@ -86,7 +86,7 @@ namespace RBX
 	// TODO: 98.55% match
 	G3D::CoordinateFrame Feature::computeLocalCoordinateFrame() const
 	{
-		PartInstance* part = fastDynamicCast<PartInstance>(getParent());
+		PartInstance* part = dynamic_cast<PartInstance*>(getParent());
 
 		if (!part)
 			return G3D::CoordinateFrame();
@@ -227,7 +227,7 @@ namespace RBX
 	{
 		if (instance)
 		{
-			PartInstance* part = Instance::fastDynamicCast<PartInstance>(instance->getParent());
+			PartInstance* part = dynamic_cast<PartInstance*>(instance->getParent());
 
 			if (part)
 				return part->getPrimitive();
@@ -255,7 +255,7 @@ namespace RBX
 	{
 		Instance::onAncestorChanged(event);
 
-		setPart(0, fastDynamicCast<Feature>(this->getParent()));
+		setPart(0, dynamic_cast<Feature*>(this->getParent()));
 
 		World* oldWorld = motorJoint()->getWorld();
 		World* wsWorld = Workspace::getWorldIfInWorkspace(this);

--- a/Client/App/v8datamodel/Flag.cpp
+++ b/Client/App/v8datamodel/Flag.cpp
@@ -30,7 +30,7 @@ namespace RBX
 
 	void Flag::onChildAdded(Instance* instance)
 	{
-		if (fastDynamicCast<PartInstance>(instance))
+		if (dynamic_cast<PartInstance*>(instance))
 		{
 			if (PartInstance* handle = getHandle())
 			{

--- a/Client/App/v8datamodel/FlagStand.cpp
+++ b/Client/App/v8datamodel/FlagStand.cpp
@@ -48,7 +48,7 @@ namespace RBX
 		{
 			for (int i = 0; i < 2; i++)
 			{
-				Flag* flag = fastDynamicCast<Flag>(PartInstance::fromPrimitive(current->getPrimitive(i))->getParent());
+				Flag* flag = dynamic_cast<Flag*>(PartInstance::fromPrimitive(current->getPrimitive(i))->getParent());
 				if (flag)
 					return flag;
 			}

--- a/Client/App/v8datamodel/Gyro.cpp
+++ b/Client/App/v8datamodel/Gyro.cpp
@@ -72,13 +72,13 @@ namespace RBX
 		Instance::onAncestorChanged(event);
 
 		if (event.child == this)
-			part = fastDynamicCast<PartInstance>(event.newParent);
+			part = dynamic_cast<PartInstance*>(event.newParent);
 		updateWorld();
 	}
 
 	bool BodyMover::askSetParent(const Instance* instance) const
 	{
-		return fastDynamicCast<const PartInstance>(instance) != NULL;
+		return dynamic_cast<const PartInstance*>(instance) != NULL;
 	}
 
 	Reflection::RefPropDescriptor<Rocket, PartInstance> Rocket::prop_Target("Target", "Goals", &Rocket::getTarget, &Rocket::setTarget, Reflection::PropertyDescriptor::STANDARD);

--- a/Client/App/v8datamodel/Hopper.cpp
+++ b/Client/App/v8datamodel/Hopper.cpp
@@ -23,7 +23,7 @@ namespace RBX
 
 	bool Hopper::askAddChild(const Instance* instance) const
 	{
-		return fastDynamicCast<const BackpackItem>(instance) != NULL;
+		return dynamic_cast<const BackpackItem*>(instance) != NULL;
 	}
 
 	bool Hopper::askSetParent(const Instance* instance) const
@@ -48,7 +48,7 @@ namespace RBX
 
 	bool BackpackItem::isEnabled()
 	{
-		return getParent() && fastDynamicCast<Backpack>(getParent()) != NULL;
+		return getParent() && dynamic_cast<Backpack*>(getParent()) != NULL;
 	}
 
 	void BackpackItem::setTextureId(const TextureId& value)

--- a/Client/App/v8datamodel/JointsService.cpp
+++ b/Client/App/v8datamodel/JointsService.cpp
@@ -66,14 +66,14 @@ namespace RBX
 	{
 		Instance::onDescendentAdded(instance);
 
-		IRenderable* renderable = fastDynamicCast<IRenderable>(instance);
+		IRenderable* renderable = dynamic_cast<IRenderable*>(instance);
 		if (renderable)
 			onAdded(renderable);
 	}
 
 	void JointsService::onDescendentRemoving(const boost::shared_ptr<Instance>& instance)
 	{
-		IRenderable* renderable = fastDynamicCast<IRenderable>(instance.get());
+		IRenderable* renderable = dynamic_cast<IRenderable*>(instance.get());
 		if (renderable)
 			onRemoving(renderable);
 

--- a/Client/App/v8datamodel/Lighting.cpp
+++ b/Client/App/v8datamodel/Lighting.cpp
@@ -161,7 +161,7 @@ namespace RBX
 
 	void Lighting::onChildAdded(Instance* child)
 	{
-		Sky* newSky = fastDynamicCast<Sky>(child);
+		Sky* newSky = dynamic_cast<Sky*>(child);
 
 		if (newSky)
 		{
@@ -202,6 +202,6 @@ namespace RBX
 
 	bool Lighting::askAddChild(const Instance* instance) const
 	{
-		return fastDynamicCast<const Sky>(instance) != NULL;
+		return dynamic_cast<const Sky*>(instance) != NULL;
 	}
 }

--- a/Client/App/v8datamodel/LocakBackpack.cpp
+++ b/Client/App/v8datamodel/LocakBackpack.cpp
@@ -32,7 +32,7 @@ namespace RBX
 	{
 		Instance* child = event.child.get();
 
-		if (Network::Player* player = fastDynamicCast<Network::Player>(child))
+		if (Network::Player* player = dynamic_cast<Network::Player*>(child))
 		{
 			if (player == Network::Players::findLocalPlayer(this))
 			{
@@ -41,11 +41,11 @@ namespace RBX
 		}
 		else
 		{
-			if (Backpack* backpack = fastDynamicCast<Backpack>(child))
+			if (Backpack* backpack = dynamic_cast<Backpack*>(child))
 			{
 				onLocalBackpackAdded(backpack);
 			}
-			else if (BackpackItem* backpackItem = fastDynamicCast<BackpackItem>(child))
+			else if (BackpackItem* backpackItem = dynamic_cast<BackpackItem*>(child))
 			{
 				insertBackpackItem(backpackItem);
 			}
@@ -56,7 +56,7 @@ namespace RBX
 	{
 		Instance* child = event.child.get();
 
-		if (Network::Player* player = fastDynamicCast<Network::Player>(child))
+		if (Network::Player* player = dynamic_cast<Network::Player*>(child))
 		{
 			if (player == localPlayer.get())
 			{
@@ -65,12 +65,12 @@ namespace RBX
 		}
 		else
 		{
-			if (Backpack* backpack = fastDynamicCast<Backpack>(child))
+			if (Backpack* backpack = dynamic_cast<Backpack*>(child))
 			{
 				RBXASSERT(localBackpack);
 				clearLocalBackpack();
 			}
-			else if (BackpackItem* backpackItem = fastDynamicCast<BackpackItem>(child))
+			else if (BackpackItem* backpackItem = dynamic_cast<BackpackItem*>(child))
 			{
 				removeBackpackItem(backpackItem);
 			}
@@ -81,7 +81,7 @@ namespace RBX
 	{
 		RBXASSERT(source == localCharacter.get());
 
-		BackpackItem* backpackItem = fastDynamicCast<BackpackItem>(event.instance.get());
+		BackpackItem* backpackItem = dynamic_cast<BackpackItem*>(event.instance.get());
 		if (backpackItem)
 			insertBackpackItem(backpackItem);
 	}
@@ -90,7 +90,7 @@ namespace RBX
 	{
 		RBXASSERT(source == localCharacter.get());
 
-		BackpackItem* backpackItem = fastDynamicCast<BackpackItem>(event.instance.get());
+		BackpackItem* backpackItem = dynamic_cast<BackpackItem*>(event.instance.get());
 		if (backpackItem)
 			removeBackpackItem(backpackItem);
 	}
@@ -233,13 +233,13 @@ namespace RBX
 
 		for (int i = maxId; i > minId; i--)
 		{
-			LocalBackpackItem* aItem = rbx_static_cast<LocalBackpackItem*>(getChild(i - 1));
-			LocalBackpackItem* bItem = rbx_static_cast<LocalBackpackItem*>(getChild(i));
+			LocalBackpackItem* aItem = getTypedChild<LocalBackpackItem>(i - 1);
+			LocalBackpackItem* bItem = getTypedChild<LocalBackpackItem>(i);
 
 			bItem->setItem(aItem->getItem());
 		}
 
-		LocalBackpackItem* freeItem = rbx_static_cast<LocalBackpackItem*>(getChild(minId));
+		LocalBackpackItem* freeItem = getTypedChild<LocalBackpackItem>(minId);
 		freeItem->setItem(item);
 		lastRemovedIndex = -1;
 	}
@@ -248,7 +248,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			LocalBackpackItem* current = rbx_static_cast<LocalBackpackItem*>(getChild(i));
+			LocalBackpackItem* current = getTypedChild<LocalBackpackItem>((int)i);
 			if (current->getItem() == item)
 			{
 				lastRemovedIndex = (int)i;

--- a/Client/App/v8datamodel/Message.cpp
+++ b/Client/App/v8datamodel/Message.cpp
@@ -24,7 +24,7 @@ namespace RBX
 	{
 		if (text.size() > 0)
 		{
-			if (!fastDynamicCast<Network::Player>(getParent()))
+			if (!dynamic_cast<Network::Player*>(getParent()))
 			{
 				renderFullScreen(adorn);
 			}

--- a/Client/App/v8datamodel/ModelInstance.cpp
+++ b/Client/App/v8datamodel/ModelInstance.cpp
@@ -56,7 +56,7 @@ namespace RBX
 
 	bool ModelInstance::askSetParent(const Instance* instance) const
 	{
-		return fastDynamicCast<const ModelInstance>(instance) != NULL;
+		return dynamic_cast<const ModelInstance*>(instance) != NULL;
 	}
 
 	void ModelInstance::onExtentsChanged() const
@@ -158,14 +158,14 @@ namespace RBX
 
 	static void makeJ(Instance* instance)
 	{
-		PartInstance* partInstance = Instance::fastDynamicCast<PartInstance>(instance);
+		PartInstance* partInstance = dynamic_cast<PartInstance*>(instance);
 		if (partInstance)
 		{
 			partInstance->join();
 		}
 		else
 		{
-			ModelInstance* modelInstance = Instance::fastDynamicCast<ModelInstance>(instance);
+			ModelInstance* modelInstance = dynamic_cast<ModelInstance*>(instance);
 			if (modelInstance)
 				modelInstance->for_eachChild(makeJ);
 		}
@@ -178,14 +178,14 @@ namespace RBX
 
 	static void breakJ(Instance* instance)
 	{
-		PartInstance* partInstance = Instance::fastDynamicCast<PartInstance>(instance);
+		PartInstance* partInstance = dynamic_cast<PartInstance*>(instance);
 		if (partInstance)
 		{
 			partInstance->destroyJoints();
 		}
 		else
 		{
-			ModelInstance* modelInstance = Instance::fastDynamicCast<ModelInstance>(instance);
+			ModelInstance* modelInstance = dynamic_cast<ModelInstance*>(instance);
 			if (modelInstance)
 				modelInstance->for_eachChild(breakJ);
 		}
@@ -224,7 +224,7 @@ namespace RBX
 			for (size_t i = 0; i < numChildren(); ++i)
 			{
 				const Instance* child = getChild(i);
-				const PVInstance* pvChild = fastDynamicCast<const PVInstance>(child);
+				const PVInstance* pvChild = dynamic_cast<const PVInstance*>(child);
 				if (pvChild)
 				{
 					const Primitive* primitive = pvChild->getBiggestPrimitive();
@@ -284,7 +284,7 @@ namespace RBX
 				for (int i = 0; i < count; ++i)
 				{
 					Instance* child = getChild(i);
-					PVInstance* pvChild = fastDynamicCast<PVInstance>(child);
+					PVInstance* pvChild = dynamic_cast<PVInstance*>(child);
 					if (pvChild)
 						pvChild->legacyTraverseState(myState);
 				}
@@ -308,7 +308,7 @@ namespace RBX
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
 			Instance* child = getChild(i);
-			PVInstance* pvChild = fastDynamicCast<PVInstance>(child);
+			PVInstance* pvChild = dynamic_cast<PVInstance*>(child);
 			if (pvChild)
 			{
 				if (pvChild->hitTest(worldRay, worldHitPoint))
@@ -348,7 +348,7 @@ namespace RBX
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
 			Instance* child = getChild(i);
-			ICameraSubject* cameraSubject = fastDynamicCast<ICameraSubject>(child);
+			ICameraSubject* cameraSubject = dynamic_cast<ICameraSubject*>(child);
 			if (cameraSubject)
 				cameraSubject->onCameraNear(distance);
 		}

--- a/Client/App/v8datamodel/PVInstance.cpp
+++ b/Client/App/v8datamodel/PVInstance.cpp
@@ -37,8 +37,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
-			Instance* child = getChild(i);
-			PVInstance* pvChild = fastDynamicCast<PVInstance>(child);
+			PVInstance* pvChild = queryTypedChild<PVInstance>((int)i);
 			if (pvChild)
 				pvChild->clearLegacyOffset();
 		}
@@ -76,7 +75,7 @@ namespace RBX
 	{
 		dirtyAll();
 
-		PVInstance* pvParent = fastDynamicCast<PVInstance>(getParent());
+		PVInstance* pvParent = queryTypedParent<PVInstance>();
 		if (pvParent)
 			pvParent->onChildControllerChanged();
 	}
@@ -87,8 +86,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
-			Instance* child = getChild(i);
-			PVInstance* pvChild = fastDynamicCast<PVInstance>(child);
+			PVInstance* pvChild = queryTypedChild<PVInstance>((int)i);
 			if (pvChild)
 				pvChild->onParentControllerChanged();
 		}
@@ -119,8 +117,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
-			const Instance* child = getChild(i);
-			const IControllable* controllableChild = fastDynamicCast<const IControllable>(child);
+			const IControllable* controllableChild = queryTypedChild<IControllable>((int)i);
 			if (controllableChild)
 			{
 				if (controllableChild->isControllable())
@@ -135,7 +132,7 @@ namespace RBX
 	{
 		if (!isTopLevelPVInstance())
 		{
-			G3D::ReferenceCountedPointer<RBX::Controller> controller = rbx_static_cast<PVInstance*>(getParent())->TopPVController;
+			G3D::ReferenceCountedPointer<RBX::Controller> controller = getTypedParent<PVInstance>()->TopPVController;
 
 			if (controller.notNull())
 			{
@@ -150,7 +147,7 @@ namespace RBX
 
 	void PVInstance::onChildAdded(Instance* instance)
 	{
-		PVInstance* pvInstance = fastDynamicCast<PVInstance>(instance);
+		PVInstance* pvInstance = dynamic_cast<PVInstance*>(instance);
 		if (pvInstance)
 		{
 			pvInstance->onChildControllerChanged();
@@ -160,7 +157,7 @@ namespace RBX
 
 	void PVInstance::onChildRemoving(Instance* instance)
 	{
-		PVInstance* pvInstance = fastDynamicCast<PVInstance>(instance);
+		PVInstance* pvInstance = dynamic_cast<PVInstance*>(instance);
 		if (pvInstance)
 		{
 			pvInstance->onChildControllerChanged();
@@ -198,7 +195,7 @@ namespace RBX
 
 	void PVInstance::onExtentsChanged() const
 	{
-		PVInstance* pvParent = fastDynamicCast<PVInstance>(getParent());
+		const PVInstance* pvParent = queryTypedParent<PVInstance>();
 		if (pvParent)
 			pvParent->onExtentsChanged();
 	}

--- a/Client/App/v8datamodel/PartInstance.cpp
+++ b/Client/App/v8datamodel/PartInstance.cpp
@@ -329,7 +329,7 @@ namespace RBX
 
 	bool PartInstance::getLocked(Instance* instance)
 	{
-		PartInstance* thisPart = fastDynamicCast<PartInstance>(instance);
+		PartInstance* thisPart = dynamic_cast<PartInstance*>(instance);
 
 		if (thisPart)
 		{
@@ -556,7 +556,7 @@ namespace RBX
 
 	void PartInstance::findParts(Instance* instance, std::vector<boost::weak_ptr<RBX::PartInstance>>& parts)
 	{
-		if (PartInstance* part = fastDynamicCast<PartInstance>(instance))
+		if (PartInstance* part = dynamic_cast<PartInstance*>(instance))
 			parts.push_back(shared_from(part));
 
 		for (size_t i = 0; i < instance->numChildren(); i++)

--- a/Client/App/v8datamodel/RootInstance.cpp
+++ b/Client/App/v8datamodel/RootInstance.cpp
@@ -180,7 +180,7 @@ namespace RBX
 
 		if (instances.size() == 1)
 		{
-			HopperBin* hopperBin = fastDynamicCast<HopperBin>(instances[0].get());
+			HopperBin* hopperBin = dynamic_cast<HopperBin*>(instances[0].get());
 			if (hopperBin)
 			{
 				Network::Player* localPlayer = Network::Players::findLocalPlayer(this);
@@ -203,12 +203,12 @@ namespace RBX
 		if (instances.size() == 1)
 		{
 			Instance* instance = instances[0].get();
-			if (fastDynamicCast<HopperBin>(instance))
+			if (dynamic_cast<HopperBin*>(instance))
 			{
 				instance->setParent(ServiceProvider::create<StarterPackService>(this));
 				return;
 			}
-			else if (fastDynamicCast<Tool>(instance))
+			else if (dynamic_cast<Tool*>(instance))
 			{
 				if (promptMode == ALLOW_PROMPTS && MessageBoxA(NULL, "Put this tool into the starter pack (otherwise drop into the 3d view)?", "Inserting Tool", MB_YESNO) == IDYES)
 				{
@@ -278,20 +278,20 @@ namespace RBX
 		for (size_t i = 0; i < instances.size(); ++i)
 		{
 			Instance* instance = instances[i].get();
-			if (Sky* sky = fastDynamicCast<Sky>(instance))
+			if (Sky* sky = dynamic_cast<Sky*>(instance))
 			{
 				Lighting* lighting = ServiceProvider::create<Lighting>(this);
 				lighting->replaceSky(sky);
 			}
-			else if (Team* team = fastDynamicCast<Team>(instance))
+			else if (Team* team = dynamic_cast<Team*>(instance))
 			{
 				instance->setParent(ServiceProvider::create<Teams>(this));
 			}
-			else if (HopperBin* hopperBin = fastDynamicCast<HopperBin>(instance))
+			else if (HopperBin* hopperBin = dynamic_cast<HopperBin*>(instance))
 			{
 				insertHopperBin(hopperBin);
 			}
-			else if (SpawnLocation* spawnLocation = fastDynamicCast<SpawnLocation>(instance))	
+			else if (SpawnLocation* spawnLocation = dynamic_cast<SpawnLocation*>(instance))	
 			{
 				insertSpawnLocation(spawnLocation);
 				remaining.push_back(instances[i]);
@@ -331,7 +331,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); ++i)
 		{
-			const PVInstance* pvChild = fastDynamicCast<const PVInstance>(getChild(i));
+			const PVInstance* pvChild = queryTypedChild<PVInstance>(i);
 			if (pvChild)
 			{
 				if (pvChild->isControllable())

--- a/Client/App/v8datamodel/Teams.cpp
+++ b/Client/App/v8datamodel/Teams.cpp
@@ -28,7 +28,7 @@ namespace RBX
 
 		for (size_t i = 0; i < players->numChildren(); i++)
 		{
-			Network::Player* player = fastDynamicCast<Network::Player>(players->getChild(i));
+			Network::Player* player = dynamic_cast<Network::Player*>(players->getChild(i));
 			if (player)
 			{
 				if (!player->getNeutral() && player->getTeamColor() == brickColor)
@@ -48,7 +48,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			Team* team = fastDynamicCast<Team>(getChild(i));
+			Team* team = dynamic_cast<Team*>(getChild(i));
 			if (team && team->getTeamColor() == brickColor)
 				return team;
 		}
@@ -63,7 +63,7 @@ namespace RBX
 
 		for (size_t i = 0; i < players->numChildren(); i++)
 		{
-			Network::Player* player = fastDynamicCast<Network::Player>(players->getChild(i));
+			Network::Player* player = dynamic_cast<Network::Player*>(players->getChild(i));
 			if (player)
 			{
 				if (!player->getNeutral() && player->getCharacter())
@@ -88,7 +88,7 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			Team* team = fastDynamicCast<Team>(getChild(i));
+			Team* team = dynamic_cast<Team*>(getChild(i));
 			if (team && team->getAutoAssignable() == true)
 			{
 				int count = getNumPlayersInTeam(team->getTeamColor());
@@ -111,7 +111,7 @@ namespace RBX
 
 	void Teams::onChildAdded(Instance* child)
 	{
-		if (fastDynamicCast<Team>(child))
+		if (dynamic_cast<Team*>(child))
 		{
 			boost::shared_ptr<std::vector<boost::shared_ptr<Instance>>>& myTeams = teams.write();
 			myTeams->push_back(shared_from(child));
@@ -120,7 +120,7 @@ namespace RBX
 
 	void Teams::onChildRemoving(Instance* child)
 	{
-		if (fastDynamicCast<Team>(child))
+		if (dynamic_cast<Team*>(child))
 		{
 			boost::shared_ptr<std::vector<boost::shared_ptr<Instance>>>& myTeams = teams.write();
 			myTeams->erase(std::find(myTeams->begin(), myTeams->end(), shared_from(child)));

--- a/Client/App/v8datamodel/Tool.cpp
+++ b/Client/App/v8datamodel/Tool.cpp
@@ -134,7 +134,7 @@ namespace RBX
 	{
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			if (IRenderable* renderable = fastDynamicCast<IRenderable>(getChild(i)))
+			if (IRenderable* renderable = queryTypedChild<IRenderable>((int)i))
 				renderable->render3dSelect(adorn, selectState);
 		}
 	}
@@ -186,7 +186,7 @@ namespace RBX
 
 			for (size_t i = 0; i < parent->numChildren(); i++)
 			{
-				if (fastDynamicCast<Tool>(parent->getChild(i)))
+				if (dynamic_cast<Tool*>(parent->getChild(i)))
 					total++;
 			}
 		}
@@ -227,7 +227,7 @@ namespace RBX
 		if (backendToolState == IN_WORKSPACE)
 		{
 			Instance* otherParent = other->getParent();
-			if (computeDesiredState(otherParent) == EQUIPPED && characterCanUnequipTool(fastDynamicCast<ModelInstance>(otherParent)))
+			if (computeDesiredState(otherParent) == EQUIPPED && characterCanUnequipTool(dynamic_cast<ModelInstance*>(otherParent)))
 			{
 				Network::Player* player = Network::Players::getPlayerFromCharacter(otherParent);
 				if (player && canBePickedUpByPlayer(player))

--- a/Client/App/v8datamodel/Workspace.cpp
+++ b/Client/App/v8datamodel/Workspace.cpp
@@ -46,7 +46,7 @@ namespace RBX
 
 	bool Workspace::askAddChild(const Instance* instance) const
 	{
-		return fastDynamicCast<const IRenderable>(instance) != NULL;
+		return dynamic_cast<const IRenderable*>(instance) != NULL;
 	}
 
 	const G3D::GCamera& Workspace::getGCamera() const
@@ -137,11 +137,11 @@ namespace RBX
 		RootInstance::onDescendentAdded(instance);
 		raiseDrawChanged();
 
-		IRenderable* renderable = fastDynamicCast<IRenderable>(instance);
+		IRenderable* renderable = dynamic_cast<IRenderable*>(instance);
 		if (renderable)
 			onAdded(renderable);
 
-		PVInstance* pvInstance = fastDynamicCast<PVInstance>(instance);
+		PVInstance* pvInstance = dynamic_cast<PVInstance*>(instance);
 		if (pvInstance && pvInstance->getLegacyOffset())
 		{
 			RBXASSERT(instance->getParent() == this);
@@ -155,7 +155,7 @@ namespace RBX
 
 	void Workspace::onDescendentRemoving(const boost::shared_ptr<Instance>& instance)
 	{
-		IRenderable* renderable = fastDynamicCast<IRenderable>(instance.get());
+		IRenderable* renderable = dynamic_cast<IRenderable*>(instance.get());
 		if (renderable)
 			onRemoving(renderable);
 
@@ -166,7 +166,7 @@ namespace RBX
 	template<bool isJoin>
 	static void wrapper(Instance* instance)
 	{
-		PartInstance* part = Instance::fastDynamicCast<PartInstance>(instance);
+		PartInstance* part = dynamic_cast<PartInstance*>(instance);
 		if (part)
 		{
 			if (isJoin)
@@ -200,7 +200,7 @@ namespace RBX
 	{
 		if (test.get() != parent)
 		{
-			ModelInstance* model = Instance::fastDynamicCast<ModelInstance>(test.get());
+			ModelInstance* model = dynamic_cast<ModelInstance*>(test.get());
 			if (model && !Humanoid::modelIsCharacter(model) && !model->findFirstChildOfType<PartInstance>() && !model->findFirstChildOfType<ModelInstance>())
 			{
 				boost::shared_ptr<Instance> oldParent = shared_from(model->getParent());
@@ -208,7 +208,7 @@ namespace RBX
 				clearEmptiedModels(oldParent, parent);
 			}
 
-			Flag* flag = Instance::fastDynamicCast<Flag>(test.get());
+			Flag* flag = dynamic_cast<Flag*>(test.get());
 			if (flag && !flag->findFirstChildOfType<PartInstance>())
 			{
 				boost::shared_ptr<Instance> oldParent = shared_from(flag->getParent());
@@ -407,9 +407,9 @@ namespace RBX
 
 		for (size_t i = 0; i < numChildren(); i++)
 		{
-			HopperBin* hopperBin = fastDynamicCast<HopperBin>(getChild(i));
-			ILocation* location = fastDynamicCast<ILocation>(getChild(i));
-			IRenderable* renderable = fastDynamicCast<IRenderable>(getChild(i));
+			HopperBin* hopperBin = queryTypedChild<HopperBin>((int)i);
+			ILocation* location = queryTypedChild<ILocation>((int)i);
+			IRenderable* renderable = queryTypedChild<IRenderable>((int)i);
 
 			if (location && renderable)
 			{

--- a/Client/App/v8tree/Service.cpp
+++ b/Client/App/v8tree/Service.cpp
@@ -16,9 +16,9 @@ namespace RBX
 
 	void ServiceProvider::onChildAdded(Instance* instance)
 	{
-		RBXASSERT(Instance::fastDynamicCast<ServiceProvider>(instance)==NULL);
+		RBXASSERT(dynamic_cast<ServiceProvider*>(instance)==NULL);
 
-		if (Instance::fastDynamicCast<Service>(instance))
+		if (dynamic_cast<Service*>(instance))
 		{
 			if (!instance->getClassName().empty())
 			{
@@ -57,7 +57,7 @@ namespace RBX
 
 			for (; iter != end; iter++)
 			{
-				if (fastDynamicCast<Service>(iter->get()))
+				if (dynamic_cast<Service*>(iter->get()))
 				{
 					Notifier<ServiceProvider, ServiceAdded>::raise(ServiceAdded(iter->get()), listener);
 				}
@@ -124,6 +124,6 @@ namespace RBX
 	// TODO: check match
 	bool ServiceProvider::askAddChild(const Instance* instance) const
 	{
-		return fastDynamicCast<const Service>(instance) != NULL;
+		return dynamic_cast<const Service*>(instance) != NULL;
 	}
 }

--- a/Client/App/v8world/Primitive.cpp
+++ b/Client/App/v8world/Primitive.cpp
@@ -563,14 +563,14 @@ namespace RBX
 
 	void EdgeList::removeEdge(Primitive* p, Edge* e, EdgeList& list)
 	{
+		Edge* currentEdge = list.first;
+
 		if (list.first == e)
 		{
 			list.first = e->getNext(p);
 		}
 		else
 		{
-			Edge* currentEdge = list.first;
-
 			while (currentEdge->getNext(p) != e)
 			{
 				currentEdge = currentEdge->getNext(p);

--- a/Client/Network/Player.cpp
+++ b/Client/Network/Player.cpp
@@ -30,11 +30,11 @@ static void addChild(const boost::shared_ptr<RBX::ModelInstance>& parent, const 
 
 static void setAppearanceParent(boost::shared_ptr<RBX::Instance> parent, boost::shared_ptr<RBX::Instance> instance)
 {
-	if (RBX::Instance::fastDynamicCast<RBX::CharacterAppearance>(instance.get()))
+	if (dynamic_cast<RBX::CharacterAppearance*>(instance.get()))
 	{
 		instance->setParent(parent.get());
 	}
-	else if (RBX::Instance::fastDynamicCast<RBX::Accoutrement>(instance.get()))
+	else if (dynamic_cast<RBX::Accoutrement*>(instance.get()))
 	{
 		instance->setParent(parent.get());
 	}
@@ -46,7 +46,7 @@ static void setAppearanceParent(boost::shared_ptr<RBX::Instance> parent, boost::
 
 static void setAppearanceParentNull(RBX::Instance* instance)
 {
-	if (RBX::Instance::fastDynamicCast<RBX::CharacterAppearance>(instance))
+	if (dynamic_cast<RBX::CharacterAppearance*>(instance))
 		instance->setParent(NULL);
 }
 

--- a/Client/Network/Players.cpp
+++ b/Client/Network/Players.cpp
@@ -77,7 +77,7 @@ namespace RBX
 
 		bool Players::askAddChild(const Instance* instance) const
 		{
-			return fastDynamicCast<const Player>(instance) != NULL;
+			return dynamic_cast<const Player*>(instance) != NULL;
 		}
 
 		void Players::setConnection(RakPeerInterface* peer)
@@ -122,7 +122,7 @@ namespace RBX
 
 		void Players::reportAbuse(boost::shared_ptr<Instance> player, std::string comment)
 		{
-			reportAbuse(fastDynamicCast<Player>(player.get()), comment);
+			reportAbuse(dynamic_cast<Player*>(player.get()), comment);
 		}
 
 		void Players::reportAbuse(Player* player, std::string comment)
@@ -256,7 +256,7 @@ namespace RBX
 
 		void Players::onChildAdded(Instance* child)
 		{
-			Player* player = fastDynamicCast<Player>(child);
+			Player* player = dynamic_cast<Player*>(child);
 			if (!player)
 				return;
 
@@ -284,7 +284,7 @@ namespace RBX
 		
 		void Players::onChildRemoving(Instance* child)
 		{
-			Player* player = fastDynamicCast<Player>(child);
+			Player* player = dynamic_cast<Player*>(child);
 			if (!player)
 				return;
 

--- a/Client/Network/Replicator.cpp
+++ b/Client/Network/Replicator.cpp
@@ -44,7 +44,7 @@ public:
 
 static void checkDisconnect(RBX::Instance* instance)
 {
-	RBX::Network::Replicator* repl = RBX::Instance::fastDynamicCast<RBX::Network::Replicator>(instance);
+	RBX::Network::Replicator* repl = dynamic_cast<RBX::Network::Replicator*>(instance);
 
 	if (repl && repl->disconnected)
 	{
@@ -200,7 +200,7 @@ namespace RBX
 
 		bool Replicator::wantReplicate(const Instance* source) const
 		{
-			return fastDynamicCast<const Camera>(source) == NULL ? true : false;
+			return dynamic_cast<const Camera*>(source) == NULL ? true : false;
 		}
 
 		bool Replicator::canSendItems()

--- a/Client/Network/Replicator.h
+++ b/Client/Network/Replicator.h
@@ -318,7 +318,7 @@ namespace RBX
 			virtual ~Peer();
 			virtual bool askAddChild(const Instance* instance) const
 			{
-				return fastDynamicCast<const Replicator>(instance) != NULL;
+				return dynamic_cast<const Replicator*>(instance) != NULL;
 			}
 			RakPeerInterface* peerInterface();
 			void updateLogger();

--- a/Client/Network/Server.cpp
+++ b/Client/Network/Server.cpp
@@ -12,7 +12,7 @@ static RBX::Reflection::BoundFuncDesc<RBX::Network::Server, void(std::string, st
 
 static bool isReplicator(boost::shared_ptr<RBX::Instance> instance)
 {
-	return RBX::Instance::fastDynamicCast<const RBX::Network::Replicator>(instance.get()) != NULL;
+	return dynamic_cast<const RBX::Network::Replicator*>(instance.get()) != NULL;
 }
 
 namespace RBX

--- a/Client/Network/Server.h
+++ b/Client/Network/Server.h
@@ -63,7 +63,7 @@ namespace RBX
 			virtual void onServiceProvider(const ServiceProvider* oldProvider, const ServiceProvider* newProvider);
 			virtual bool askAddChild(const Instance* instance) const
 			{
-				return fastDynamicCast<const ClientProxy>(instance) != NULL;
+				return dynamic_cast<const ClientProxy*>(instance) != NULL;
 			}
 			
 		private:


### PR DESCRIPTION
One thing that can be noticed in the discovered NoOpt PDB symbols is that there are no references to an Instance::fastDynamicCast function (referenced in assertion messages of later client builds from 2013ish), which is not expected as, if it existed, it should be present in practically every module in v8datamodel that is listed in them.

Based on this discovery, this commit removes all references to fastDynamicCast and adds some extra template functions in Instance and a few other miscellaneous ones that are all inlined in every release build of RBXGS. For the Instance functions in particular, each CRC matches the NoOpt data; this also required the RBXASSERT macro to be changed.

Function matches in PVInstance are also improved.